### PR TITLE
Phase 3: report page UIs (student, transcript, midterm, grades)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kmitl-x",
   "description": "Transform KMITL Student Information System UI/UX with enhanced features for a better experience.",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "license": "MIT",
   "type": "module",
   "scripts": {

--- a/src/libs/components/common/Button.svelte
+++ b/src/libs/components/common/Button.svelte
@@ -1,0 +1,6 @@
+<button
+  on:click
+  class="rounded-lg py-1 px-3 bg-orange-500/10 text-orange-500 text-xs hover:scale-105 transition-all"
+>
+  <slot />
+</button>

--- a/src/libs/components/common/PageHeader.svelte
+++ b/src/libs/components/common/PageHeader.svelte
@@ -1,0 +1,24 @@
+<script lang="ts">
+  export let title: string;
+  export let lines: string[] = [];
+</script>
+
+<div
+  class="dark:bg-orange-500/10 bg-orange-100/50 text-orange-500 rounded font-prompt px-4 py-4 border dark:border-orange-500/50 border-orange-200"
+>
+  <div class="flex justify-between items-center gap-4">
+    <img
+      src="https://upload.wikimedia.org/wikipedia/commons/thumb/9/94/KMITL_Sublogo.svg/1024px-KMITL_Sublogo.svg.png"
+      alt="KMITL logo"
+      class="w-40 my-auto"
+    />
+    <div class="text-right my-auto">
+      <h1 class="text-2xl font-bold">{title}</h1>
+      {#each lines as line, i (line + i)}
+        {#if line}
+          <p class="text-sm">{line}</p>
+        {/if}
+      {/each}
+    </div>
+  </div>
+</div>

--- a/src/libs/components/common/PageHeader.svelte
+++ b/src/libs/components/common/PageHeader.svelte
@@ -11,6 +11,9 @@
       src="https://upload.wikimedia.org/wikipedia/commons/thumb/9/94/KMITL_Sublogo.svg/1024px-KMITL_Sublogo.svg.png"
       alt="KMITL logo"
       class="w-40 my-auto"
+      referrerpolicy="no-referrer"
+      loading="lazy"
+      decoding="async"
     />
     <div class="text-right my-auto">
       <h1 class="text-2xl font-bold">{title}</h1>

--- a/src/libs/components/common/PageShell.svelte
+++ b/src/libs/components/common/PageShell.svelte
@@ -1,0 +1,42 @@
+<script lang="ts">
+  import { onMount } from "svelte";
+  import Icon from "@iconify/svelte";
+  import { getTheme, setTheme } from "../../utils/themeManager";
+  import Button from "./Button.svelte";
+
+  let theme: "light" | "dark" = "dark";
+
+  onMount(() => {
+    theme = getTheme();
+    setTheme(theme);
+  });
+
+  function toggleTheme() {
+    theme = theme === "dark" ? "light" : "dark";
+    setTheme(theme);
+  }
+</script>
+
+<main
+  class="min-h-screen p-3 flex flex-col dark:bg-gray-900 bg-white font-prompt dark:text-white text-gray-900"
+>
+  <div class="max-w-5xl w-full mx-auto flex-1">
+    <slot />
+  </div>
+
+  <footer class="max-w-5xl w-full mx-auto flex justify-between items-end mt-6">
+    <div class="space-x-2">
+      <slot name="actions" />
+      <Button on:click={toggleTheme}>
+        <Icon
+          icon={theme === "dark" ? "ph:sun-duotone" : "ph:moon-duotone"}
+          class="my-auto text-2xl inline"
+        />
+        <span class="font-semibold">{theme === "dark" ? "Light" : "Dark"}</span>
+      </Button>
+    </div>
+    <div class="mt-auto text-right text-xs text-orange-300">
+      <p class="opacity-75">KMITL X</p>
+    </div>
+  </footer>
+</main>

--- a/src/libs/components/common/PageShell.svelte
+++ b/src/libs/components/common/PageShell.svelte
@@ -1,15 +1,11 @@
 <script lang="ts">
-  import { onMount } from "svelte";
   import Icon from "@iconify/svelte";
   import { getTheme, setTheme } from "../../utils/themeManager";
   import Button from "./Button.svelte";
 
-  let theme: "light" | "dark" = "dark";
-
-  onMount(() => {
-    theme = getTheme();
-    setTheme(theme);
-  });
+  // Initialized synchronously so the toggle shows the right state on first
+  // paint. The mount wrapper already applies the theme class to the root.
+  let theme: "light" | "dark" = getTheme();
 
   function toggleTheme() {
     theme = theme === "dark" ? "light" : "dark";

--- a/src/libs/registry/pageManifest.ts
+++ b/src/libs/registry/pageManifest.ts
@@ -16,6 +16,7 @@ export const pages: PageDefinition[] = [
     match: /u_officer\/student\.php/,
     scraper: () =>
       import("../scraper/student.scraper").then((m) => new m.StudentScraper()),
+    component: () => import("../../pages/StudentProfile.svelte"),
   },
   {
     name: "term-selectors",
@@ -50,6 +51,7 @@ export const pages: PageDefinition[] = [
       import("../scraper/midterm-score.scraper").then(
         (m) => new m.MidtermScoreScraper()
       ),
+    component: () => import("../../pages/MidtermScore.svelte"),
   },
   {
     name: "report-gradetable",
@@ -58,6 +60,7 @@ export const pages: PageDefinition[] = [
       import("../scraper/report-gradetable.scraper").then(
         (m) => new m.ReportGradetableScraper()
       ),
+    component: () => import("../../pages/GradeReport.svelte"),
   },
   {
     name: "report-transcript",
@@ -66,6 +69,7 @@ export const pages: PageDefinition[] = [
       import("../scraper/report-transcript.scraper").then(
         (m) => new m.ReportTranscriptScraper()
       ),
+    component: () => import("../../pages/Transcript.svelte"),
   },
   {
     // static image page, kept as a placeholder rather than reskinned

--- a/src/pages/GradeReport.svelte
+++ b/src/pages/GradeReport.svelte
@@ -1,0 +1,132 @@
+<script lang="ts">
+  import PageShell from "../libs/components/common/PageShell.svelte";
+  import PageHeader from "../libs/components/common/PageHeader.svelte";
+  import Icon from "@iconify/svelte";
+  import type { ReportGradeTable } from "../libs/types/report-gradetable.types";
+
+  export let studentInfo: ReportGradeTable["studentInfo"];
+  export let gradeTable: ReportGradeTable["gradeTable"] = [];
+  export let gradeSummary: ReportGradeTable["gradeSummary"];
+  export let gradeSymbol: ReportGradeTable["gradeSymbol"];
+  export let pdf: ReportGradeTable["pdf"] = "";
+
+  $: summaryRows = gradeSummary
+    ? [
+        { label: "ภาคเรียนนี้", data: gradeSummary.semesterSummary },
+        { label: "ภาคเรียนก่อน", data: gradeSummary.preSemester },
+        { label: "สะสม", data: gradeSummary.cumulation },
+      ]
+    : [];
+</script>
+
+<PageShell>
+  <PageHeader
+    title={`ผลการเรียน ${studentInfo.semester}/${studentInfo.year}`}
+    lines={[
+      `${studentInfo.studentId} ${studentInfo.thaiName}`,
+      `คณะ${studentInfo.faculty}`,
+      studentInfo.curriculum,
+    ]}
+  />
+
+  <div
+    class="mt-4 overflow-x-auto rounded-2xl border dark:border-white/10 border-slate-200"
+  >
+    <table class="w-full text-sm">
+      <thead
+        class="dark:bg-white/5 bg-slate-100 text-slate-500 dark:text-slate-400"
+      >
+        <tr>
+          <th class="px-3 py-2 text-left font-medium">รหัสวิชา</th>
+          <th class="px-3 py-2 text-left font-medium">ชื่อวิชา</th>
+          <th class="px-3 py-2 text-center font-medium">กลุ่ม</th>
+          <th class="px-3 py-2 text-center font-medium">หน่วยกิต</th>
+          <th class="px-3 py-2 text-center font-medium">เกรด</th>
+        </tr>
+      </thead>
+      <tbody>
+        {#each gradeTable as row (row.subjectCode + row.section)}
+          <tr class="border-t dark:border-white/10 border-slate-200">
+            <td class="px-3 py-2 font-medium text-orange-500">
+              {row.subjectCode}
+            </td>
+            <td class="px-3 py-2">{row.subjectName}</td>
+            <td class="px-3 py-2 text-center">{row.section}</td>
+            <td class="px-3 py-2 text-center">{row.credit}</td>
+            <td
+              class="px-3 py-2 text-center font-semibold"
+              style:color={row.gradeColor || undefined}
+            >
+              {row.grade}
+            </td>
+          </tr>
+        {/each}
+      </tbody>
+    </table>
+  </div>
+
+  {#if summaryRows.length}
+    <div
+      class="mt-4 overflow-x-auto rounded-2xl border dark:border-white/10 border-slate-200"
+    >
+      <table class="w-full text-sm">
+        <thead
+          class="dark:bg-white/5 bg-slate-100 text-slate-500 dark:text-slate-400"
+        >
+          <tr>
+            <th class="px-3 py-2 text-left font-medium"></th>
+            <th class="px-3 py-2 text-center font-medium">CA</th>
+            <th class="px-3 py-2 text-center font-medium">CP</th>
+            <th class="px-3 py-2 text-center font-medium">CD</th>
+            <th class="px-3 py-2 text-center font-medium">GP</th>
+            <th class="px-3 py-2 text-center font-medium">GPA</th>
+            <th class="px-3 py-2 text-center font-medium">สถานะ</th>
+          </tr>
+        </thead>
+        <tbody>
+          {#each summaryRows as s, i (s.label + i)}
+            <tr class="border-t dark:border-white/10 border-slate-200">
+              <td class="px-3 py-2 font-medium">{s.label}</td>
+              <td class="px-3 py-2 text-center">{s.data.ca || "-"}</td>
+              <td class="px-3 py-2 text-center">{s.data.cp || "-"}</td>
+              <td class="px-3 py-2 text-center">{s.data.cd || "-"}</td>
+              <td class="px-3 py-2 text-center">{s.data.gp || "-"}</td>
+              <td class="px-3 py-2 text-center font-semibold text-orange-500">
+                {s.data.gpsGpa || "-"}
+              </td>
+              <td class="px-3 py-2 text-center">{s.data.status || "-"}</td>
+            </tr>
+          {/each}
+        </tbody>
+      </table>
+    </div>
+  {/if}
+
+  {#if gradeSymbol && gradeSymbol.symbols.length}
+    <div
+      class="mt-3 flex flex-wrap gap-x-6 gap-y-1 text-xs text-slate-500 dark:text-slate-400"
+    >
+      {#each gradeSymbol.symbols as sym, i (sym.symbol + i)}
+        <span
+          ><span class="font-semibold" style:color={sym.color || undefined}
+            >{sym.symbol}</span
+          > = {sym.description}</span
+        >
+      {/each}
+    </div>
+  {/if}
+
+  <svelte:fragment slot="actions">
+    {#if pdf}
+      <a
+        href={pdf}
+        target="_blank"
+        rel="noopener noreferrer"
+        class="rounded-lg py-1 px-3 bg-orange-500/10 text-orange-500 text-xs hover:scale-105 transition-all inline-flex items-center gap-1"
+      >
+        <Icon icon="ph:file-pdf-light" class="text-2xl inline" />
+        <span class="font-semibold">เปิด PDF</span>
+      </a>
+    {/if}
+  </svelte:fragment>
+</PageShell>

--- a/src/pages/MidtermScore.svelte
+++ b/src/pages/MidtermScore.svelte
@@ -1,0 +1,74 @@
+<script lang="ts">
+  import PageShell from "../libs/components/common/PageShell.svelte";
+  import PageHeader from "../libs/components/common/PageHeader.svelte";
+  import type { MidtermScore } from "../libs/types/midterm-score.types";
+
+  export let studentInfo: MidtermScore["studentInfo"];
+  export let midtermScores: MidtermScore["midtermScores"] = [];
+  export let note: MidtermScore["note"] = "";
+  export let scoreSymbols: MidtermScore["scoreSymbols"] = [];
+</script>
+
+<PageShell>
+  <PageHeader
+    title={`คะแนนกลางภาค ${studentInfo.semester}/${studentInfo.year}`}
+    lines={[
+      `${studentInfo.studentId} ${studentInfo.thaiName}`,
+      `คณะ${studentInfo.faculty}`,
+      studentInfo.curriculum,
+    ]}
+  />
+
+  <div
+    class="mt-4 overflow-x-auto rounded-2xl border dark:border-white/10 border-slate-200"
+  >
+    <table class="w-full text-sm">
+      <thead
+        class="dark:bg-white/5 bg-slate-100 text-slate-500 dark:text-slate-400"
+      >
+        <tr>
+          <th class="px-3 py-2 text-left font-medium">รหัสวิชา</th>
+          <th class="px-3 py-2 text-left font-medium">ชื่อวิชา</th>
+          <th class="px-3 py-2 text-center font-medium">กลุ่ม</th>
+          <th class="px-3 py-2 text-center font-medium">คะแนน 1</th>
+          <th class="px-3 py-2 text-center font-medium">คะแนน 2</th>
+          <th class="px-3 py-2 text-center font-medium">คะแนน 3</th>
+          <th class="px-3 py-2 text-center font-medium">คะแนน 4</th>
+        </tr>
+      </thead>
+      <tbody>
+        {#each midtermScores as subject (subject.subjectCode + subject.section)}
+          <tr class="border-t dark:border-white/10 border-slate-200">
+            <td class="px-3 py-2 font-medium text-orange-500">
+              {subject.subjectCode}
+            </td>
+            <td class="px-3 py-2">{subject.subjectName}</td>
+            <td class="px-3 py-2 text-center">{subject.section}</td>
+            {#each subject.scores as score, si (si)}
+              <td class="px-3 py-2 text-center">{score}</td>
+            {/each}
+          </tr>
+        {/each}
+      </tbody>
+    </table>
+  </div>
+
+  {#if note}
+    <p class="mt-3 text-sm text-slate-500 dark:text-slate-400">
+      หมายเหตุ: {note}
+    </p>
+  {/if}
+
+  {#if scoreSymbols.length}
+    <div
+      class="mt-3 flex flex-wrap gap-x-6 gap-y-1 text-xs text-slate-500 dark:text-slate-400"
+    >
+      {#each scoreSymbols as sym, i (sym.symbol + i)}
+        <span
+          ><span class="font-semibold text-orange-500">{sym.symbol}</span> =
+          {sym.description}</span
+        >
+      {/each}
+    </div>
+  {/if}
+</PageShell>

--- a/src/pages/StudentProfile.svelte
+++ b/src/pages/StudentProfile.svelte
@@ -1,0 +1,99 @@
+<script lang="ts">
+  import PageShell from "../libs/components/common/PageShell.svelte";
+  import Icon from "@iconify/svelte";
+  import type { StudentProfile } from "../libs/types/student.types";
+
+  export let thaiTitle: StudentProfile["thaiTitle"] = "";
+  export let thaiFullName: StudentProfile["thaiFullName"] = "";
+  export let englishTitle: StudentProfile["englishTitle"] = "";
+  export let englishFullName: StudentProfile["englishFullName"] = "";
+  export let studentId: StudentProfile["studentId"] = "";
+  export let nationalId: StudentProfile["nationalId"] = "";
+  export let gender: StudentProfile["gender"] = "";
+  export let birthDate: StudentProfile["birthDate"] = "";
+  export let status: StudentProfile["status"] = "";
+  export let admissionType: StudentProfile["admissionType"] = "";
+  export let admissionYear: StudentProfile["admissionYear"] = "";
+  export let graduationYear: StudentProfile["graduationYear"] = "";
+  export let graduationDate: StudentProfile["graduationDate"] = "";
+  export let faculty: StudentProfile["faculty"] = "";
+  export let department: StudentProfile["department"] = "";
+  export let curriculum: StudentProfile["curriculum"] = "";
+  export let bankAccount: StudentProfile["bankAccount"] = "";
+
+  $: infoGroups = [
+    {
+      title: "ข้อมูลส่วนตัว",
+      rows: [
+        { label: "เลขประจำตัวประชาชน", value: nationalId },
+        { label: "เพศ", value: gender },
+        { label: "วันเกิด", value: birthDate },
+        { label: "สถานะ", value: status },
+      ],
+    },
+    {
+      title: "ข้อมูลการศึกษา",
+      rows: [
+        { label: "คณะ", value: faculty },
+        { label: "ภาควิชา", value: department },
+        { label: "หลักสูตร", value: curriculum },
+        { label: "ประเภทการรับเข้า", value: admissionType },
+        { label: "ปีที่เข้าศึกษา", value: admissionYear },
+        { label: "ปีที่สำเร็จการศึกษา", value: graduationYear },
+        { label: "วันที่สำเร็จการศึกษา", value: graduationDate },
+      ],
+    },
+    {
+      title: "ข้อมูลอื่น ๆ",
+      rows: [{ label: "บัญชีธนาคาร", value: bankAccount }],
+    },
+  ];
+</script>
+
+<PageShell>
+  <div
+    class="dark:bg-orange-500/10 bg-orange-100/50 rounded-2xl border dark:border-orange-500/40 border-orange-200 p-6 flex items-center gap-5"
+  >
+    <div
+      class="w-20 h-20 rounded-full bg-orange-500 text-white flex items-center justify-center text-3xl font-bold shrink-0"
+    >
+      {thaiFullName ? thaiFullName.charAt(0) : "?"}
+    </div>
+    <div class="min-w-0">
+      <h1 class="text-2xl font-bold text-orange-500 truncate">
+        {thaiTitle}
+        {thaiFullName}
+      </h1>
+      <p class="text-sm text-orange-400/80 truncate">
+        {englishTitle}
+        {englishFullName}
+      </p>
+      <div
+        class="mt-2 inline-flex items-center gap-2 px-3 py-1 rounded-full bg-orange-500 text-white text-sm font-medium"
+      >
+        <Icon icon="mdi:card-account-details-outline" class="text-base" />
+        {studentId}
+      </div>
+    </div>
+  </div>
+
+  <div class="grid gap-4 md:grid-cols-2 mt-4">
+    {#each infoGroups as group, gi (group.title + gi)}
+      <div
+        class="rounded-2xl border dark:border-white/10 border-slate-200 dark:bg-white/5 bg-slate-50 p-5"
+      >
+        <h2 class="text-sm font-semibold text-orange-500 mb-3">{group.title}</h2>
+        <dl class="space-y-2">
+          {#each group.rows as row, ri (row.label + ri)}
+            <div class="flex justify-between gap-4 text-sm">
+              <dt class="text-slate-500 dark:text-slate-400">{row.label}</dt>
+              <dd class="text-right font-medium break-words">
+                {row.value || "-"}
+              </dd>
+            </div>
+          {/each}
+        </dl>
+      </div>
+    {/each}
+  </div>
+</PageShell>

--- a/src/pages/Transcript.svelte
+++ b/src/pages/Transcript.svelte
@@ -1,0 +1,88 @@
+<script lang="ts">
+  import PageShell from "../libs/components/common/PageShell.svelte";
+  import PageHeader from "../libs/components/common/PageHeader.svelte";
+  import Icon from "@iconify/svelte";
+  import type { TranscriptData } from "../libs/types/report-transcript.types";
+
+  export let studentInfo: TranscriptData["studentInfo"];
+  export let transcriptObject: TranscriptData["transcriptObject"];
+  export let pdf: TranscriptData["pdf"] = "";
+
+  $: birth = studentInfo?.dateOfBirth;
+  $: issued = transcriptObject?.dateIssued;
+</script>
+
+<PageShell>
+  <PageHeader
+    title="ทรานสคริปต์"
+    lines={[
+      `${studentInfo.studentId} ${studentInfo.name}`,
+      studentInfo.degree,
+      studentInfo.major,
+    ]}
+  />
+
+  <div class="grid gap-4 sm:grid-cols-2 mt-4">
+    <div
+      class="rounded-2xl border dark:border-white/10 border-slate-200 dark:bg-white/5 bg-slate-50 p-6 text-center"
+    >
+      <p class="text-sm text-slate-500 dark:text-slate-400">หน่วยกิตสะสม</p>
+      <p class="text-4xl font-bold text-orange-500 mt-1">
+        {transcriptObject.totalCredits}
+      </p>
+    </div>
+    <div
+      class="rounded-2xl border dark:border-white/10 border-slate-200 dark:bg-white/5 bg-slate-50 p-6 text-center"
+    >
+      <p class="text-sm text-slate-500 dark:text-slate-400">
+        เกรดเฉลี่ยสะสม (GPAX)
+      </p>
+      <p class="text-4xl font-bold text-orange-500 mt-1">
+        {transcriptObject.cumulativeGPA.toFixed(2)}
+      </p>
+    </div>
+  </div>
+
+  <div
+    class="rounded-2xl border dark:border-white/10 border-slate-200 dark:bg-white/5 bg-slate-50 p-5 mt-4"
+  >
+    <dl class="space-y-2 text-sm">
+      <div class="flex justify-between gap-4">
+        <dt class="text-slate-500 dark:text-slate-400">วันเกิด</dt>
+        <dd class="font-medium">
+          {birth ? `${birth.day} ${birth.month} ${birth.year}` : "-"}
+        </dd>
+      </div>
+      <div class="flex justify-between gap-4">
+        <dt class="text-slate-500 dark:text-slate-400">วันที่เข้าศึกษา</dt>
+        <dd class="font-medium">{studentInfo.dateOfAdmission || "-"}</dd>
+      </div>
+      <div class="flex justify-between gap-4">
+        <dt class="text-slate-500 dark:text-slate-400">วันที่สำเร็จการศึกษา</dt>
+        <dd class="font-medium">{studentInfo.dateOfGraduation || "-"}</dd>
+      </div>
+      <div class="flex justify-between gap-4">
+        <dt class="text-slate-500 dark:text-slate-400">วันที่ออกเอกสาร</dt>
+        <dd class="font-medium">
+          {issued && issued.month
+            ? `${issued.month} ${issued.day}, ${issued.year}`
+            : "-"}
+        </dd>
+      </div>
+    </dl>
+  </div>
+
+  <svelte:fragment slot="actions">
+    {#if pdf}
+      <a
+        href={pdf}
+        target="_blank"
+        rel="noopener noreferrer"
+        class="rounded-lg py-1 px-3 bg-orange-500/10 text-orange-500 text-xs hover:scale-105 transition-all inline-flex items-center gap-1"
+      >
+        <Icon icon="ph:file-pdf-light" class="text-2xl inline" />
+        <span class="font-semibold">เปิด PDF</span>
+      </a>
+    {/if}
+  </svelte:fragment>
+</PageShell>

--- a/src/pages/Transcript.svelte
+++ b/src/pages/Transcript.svelte
@@ -50,7 +50,9 @@
       <div class="flex justify-between gap-4">
         <dt class="text-slate-500 dark:text-slate-400">วันเกิด</dt>
         <dd class="font-medium">
-          {birth ? `${birth.day} ${birth.month} ${birth.year}` : "-"}
+          {birth && birth.day
+            ? `${birth.day} ${birth.month} ${birth.year}`
+            : "-"}
         </dd>
       </div>
       <div class="flex justify-between gap-4">


### PR DESCRIPTION
Builds four of the five scraped-but-headless pages on the new stack, so visiting them shows a reskinned UI instead of falling through to the original page.

## New pages
- Student profile (u_officer/student.php)
- Transcript (report_transcript_show2.php)
- Midterm score (midterm_score.php)
- Grade report (report_gradetable_show.php)

## Shared
- components/common Button, PageHeader, and PageShell (theme init + toggle + footer), so the pages are consistent and DRY.
- Registered the components in the page manifest. Bumped dev to 2.4.0.

## Verification
- typecheck: 0 errors (1 pre-existing warning)
- eslint: 0 errors
- vitest: 22 tests pass
- Chrome and Firefox build

## Notes
- The term selector page is deferred to a follow-up. The native selector still works and now leads into these reskinned show pages, so there is no regression.
- Report labels are Thai for now; full i18n label extraction using the Phase 2 i18n layer is a later pass.
- Needs a live check on a logged-in reg.kmitl.ac.th session, which cannot run in CI.