### PR TITLE
Phase 4: registration eligibility and offered-subjects pages

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kmitl-x",
   "description": "Transform KMITL Student Information System UI/UX with enhanced features for a better experience.",
-  "version": "2.4.1",
+  "version": "2.5.0",
   "license": "MIT",
   "type": "module",
   "scripts": {

--- a/src/libs/registry/pageManifest.ts
+++ b/src/libs/registry/pageManifest.ts
@@ -20,7 +20,7 @@ export const pages: PageDefinition[] = [
   },
   {
     name: "term-selectors",
-    match: /u_student\/(report_(examtable|studytable|gradetable))\.php/,
+    match: /u_student\/(report_(examtable|studytable|gradetable)|ownersubjweb)\.php/,
     scraper: () =>
       import("../scraper/term-selectors.scraper").then(
         (m) => new m.TermSelectorsScraper()
@@ -71,6 +71,24 @@ export const pages: PageDefinition[] = [
         (m) => new m.ReportTranscriptScraper()
       ),
     component: () => import("../../pages/Transcript.svelte"),
+  },
+  {
+    name: "ownersubjweb-show",
+    match: /u_student\/ownersubjweb_show\.php/,
+    scraper: () =>
+      import("../scraper/ownersubjweb.scraper").then(
+        (m) => new m.OwnersubjwebScraper()
+      ),
+    component: () => import("../../pages/OwnersubjwebShow.svelte"),
+  },
+  {
+    name: "check-regis",
+    match: /u_student\/check_regis_no_right\.php/,
+    scraper: () =>
+      import("../scraper/check-regis.scraper").then(
+        (m) => new m.CheckRegisScraper()
+      ),
+    component: () => import("../../pages/CheckRegis.svelte"),
   },
   {
     // static image page, kept as a placeholder rather than reskinned

--- a/src/libs/scraper/check-regis.scraper.test.ts
+++ b/src/libs/scraper/check-regis.scraper.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from "vitest";
+import { CheckRegisScraper } from "./check-regis.scraper";
+
+describe("CheckRegisScraper", () => {
+  it("extracts student info, the status message, and links", async () => {
+    const html = `
+      <div id="div_student_id">&nbsp; 68010488 </div>
+      <div id="div_tname">&nbsp;First&nbsp;&nbsp;Last</div>
+      <div id="div_semester">&nbsp;1/2569</div>
+      <a href="https://x/educalendar/">calendar</a>
+      <a href="https://x/u_student/regis.php?student_id=68010488"><h1><font color="#0000FF">eligible message</font></h1></a>`;
+    const doc = new DOMParser().parseFromString(html, "text/html");
+    const r = await new CheckRegisScraper().scrape(doc);
+
+    expect(r.studentId).toBe("68010488");
+    expect(r.name).toBe("First Last");
+    expect(r.semester).toBe("1/2569");
+    expect(r.statusMessage).toBe("eligible message");
+    expect(r.statusColor).toBe("#0000FF");
+    expect(r.registerUrl).toContain("regis.php");
+    expect(r.calendarUrl).toContain("educalendar");
+  });
+});

--- a/src/libs/scraper/check-regis.scraper.ts
+++ b/src/libs/scraper/check-regis.scraper.ts
@@ -1,0 +1,32 @@
+import type { CheckRegis } from "../types/check-regis.types";
+import { BaseScraper } from "./baseScraper";
+
+export class CheckRegisScraper extends BaseScraper {
+  public async scrape(document: Document): Promise<CheckRegis> {
+    const text = (id: string) =>
+      (document.getElementById(id)?.textContent || "").replace(/\s+/g, " ").trim();
+
+    const statusLink = document.querySelector<HTMLAnchorElement>(
+      'a[href*="regis.php"]'
+    );
+    const statusEl = statusLink?.querySelector("h1, font") ?? statusLink;
+    const statusMessage = (statusEl?.textContent || "")
+      .replace(/\s+/g, " ")
+      .trim();
+    const statusColor =
+      statusLink?.querySelector("font")?.getAttribute("color") || "";
+    const calendarLink = document.querySelector<HTMLAnchorElement>(
+      'a[href*="educalendar"]'
+    );
+
+    return {
+      studentId: text("div_student_id"),
+      name: text("div_tname"),
+      semester: text("div_semester"),
+      statusMessage,
+      statusColor,
+      registerUrl: statusLink?.href || "",
+      calendarUrl: calendarLink?.href || "",
+    };
+  }
+}

--- a/src/libs/scraper/ownersubjweb.scraper.test.ts
+++ b/src/libs/scraper/ownersubjweb.scraper.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "vitest";
+import { OwnersubjwebScraper } from "./ownersubjweb.scraper";
+
+describe("OwnersubjwebScraper", () => {
+  it("extracts subjects, credits, and the term", async () => {
+    const html = `
+      <strong>รายวิชาประจำปีการศึกษา 1/2568</strong>
+      <table><tbody>
+        <tr>
+          <td><a href="https://x/subjectweb/index.php?subject_id=01006020">01006020&nbsp;&nbsp;GENERAL PHYSICS 1</a></td>
+          <td>3 (3-0)</td>
+        </tr>
+        <tr>
+          <td><a href="https://x/subjectweb/index.php?subject_id=01006021">01006021&nbsp;&nbsp;PHYSICS LAB</a></td>
+          <td>1 (0-3)</td>
+        </tr>
+      </tbody></table>`;
+    const doc = new DOMParser().parseFromString(html, "text/html");
+    const result = await new OwnersubjwebScraper().scrape(doc);
+
+    expect(result.semester).toBe("1");
+    expect(result.year).toBe("2568");
+    expect(result.subjects).toHaveLength(2);
+    expect(result.subjects[0].code).toBe("01006020");
+    expect(result.subjects[0].name).toBe("GENERAL PHYSICS 1");
+    expect(result.subjects[0].credit).toBe("3 (3-0)");
+    expect(result.subjects[0].url).toContain("subject_id=01006020");
+  });
+
+  it("returns an empty list when there are no subjects", async () => {
+    const doc = new DOMParser().parseFromString("<p>empty</p>", "text/html");
+    const result = await new OwnersubjwebScraper().scrape(doc);
+    expect(result.subjects).toHaveLength(0);
+  });
+});

--- a/src/libs/scraper/ownersubjweb.scraper.ts
+++ b/src/libs/scraper/ownersubjweb.scraper.ts
@@ -1,0 +1,53 @@
+import type {
+  OwnersubjwebData,
+  OwnersubjwebSubject,
+} from "../types/ownersubjweb.types";
+import { BaseScraper } from "./baseScraper";
+
+export class OwnersubjwebScraper extends BaseScraper {
+  public async scrape(document: Document): Promise<OwnersubjwebData> {
+    // Each subject is a link to the subject detail page. The credit is in the
+    // sibling cell of the same row.
+    const links = Array.from(
+      document.querySelectorAll<HTMLAnchorElement>('a[href*="subject_id="]')
+    );
+
+    const subjects: OwnersubjwebSubject[] = links.map((link) => {
+      const raw = (link.textContent || "").replace(/\s+/g, " ").trim();
+      const match = raw.match(/^(\S+)\s+(.*)$/);
+      const code = match ? match[1] : raw;
+      const name = match ? match[2] : "";
+
+      const row = link.closest("tr");
+      const cells = row ? Array.from(row.querySelectorAll("td")) : [];
+      const credit =
+        cells.length > 1
+          ? (cells[cells.length - 1].textContent || "")
+              .replace(/\s+/g, " ")
+              .trim()
+          : "";
+
+      return { code, name, credit, url: link.href };
+    });
+
+    const strongs = Array.from(document.querySelectorAll("strong")).map((s) =>
+      (s.textContent || "").replace(/\s+/g, " ").trim()
+    );
+
+    let semester = "";
+    let year = "";
+    for (const s of strongs) {
+      const m = s.match(/(\d)\/(\d{4})/);
+      if (m) {
+        semester = m[1];
+        year = m[2];
+        break;
+      }
+    }
+
+    // Section labels (faculty/curriculum), excluding the semester header.
+    const headings = strongs.filter((t) => t && !/\d\/\d{4}/.test(t));
+
+    return { semester, year, headings, subjects };
+  }
+}

--- a/src/libs/types/check-regis.types.ts
+++ b/src/libs/types/check-regis.types.ts
@@ -1,0 +1,10 @@
+export interface CheckRegis {
+  studentId: string;
+  name: string;
+  semester: string;
+  // The eligibility message shown by the registrar, with its own color.
+  statusMessage: string;
+  statusColor: string;
+  registerUrl: string;
+  calendarUrl: string;
+}

--- a/src/libs/types/ownersubjweb.types.ts
+++ b/src/libs/types/ownersubjweb.types.ts
@@ -1,0 +1,13 @@
+export interface OwnersubjwebSubject {
+  code: string;
+  name: string;
+  credit: string;
+  url: string;
+}
+
+export interface OwnersubjwebData {
+  semester: string;
+  year: string;
+  headings: string[];
+  subjects: OwnersubjwebSubject[];
+}

--- a/src/pages/CheckRegis.svelte
+++ b/src/pages/CheckRegis.svelte
@@ -1,0 +1,54 @@
+<script lang="ts">
+  import PageShell from "../libs/components/common/PageShell.svelte";
+  import PageHeader from "../libs/components/common/PageHeader.svelte";
+  import Icon from "@iconify/svelte";
+  import type { CheckRegis } from "../libs/types/check-regis.types";
+
+  export let studentId: CheckRegis["studentId"] = "";
+  export let name: CheckRegis["name"] = "";
+  export let semester: CheckRegis["semester"] = "";
+  export let statusMessage: CheckRegis["statusMessage"] = "";
+  export let statusColor: CheckRegis["statusColor"] = "";
+  export let registerUrl: CheckRegis["registerUrl"] = "";
+  export let calendarUrl: CheckRegis["calendarUrl"] = "";
+</script>
+
+<PageShell>
+  <PageHeader
+    title="ตรวจสอบสิทธิ์การลงทะเบียน"
+    lines={[`${studentId} ${name}`, `ภาคการศึกษา ${semester}`]}
+  />
+
+  <div
+    class="mt-4 rounded-2xl border dark:border-white/10 border-slate-200 dark:bg-white/5 bg-slate-50 p-8 text-center"
+  >
+    <Icon
+      icon="mdi:clipboard-check-outline"
+      class="w-12 h-12 text-orange-500 mx-auto mb-3"
+    />
+    <p class="text-lg font-semibold" style:color={statusColor || undefined}>
+      {statusMessage || "-"}
+    </p>
+  </div>
+
+  <div class="mt-4 flex flex-wrap gap-3 justify-center">
+    {#if registerUrl}
+      <a
+        href={registerUrl}
+        class="rounded-xl bg-orange-500 text-white font-semibold px-5 py-2.5 hover:bg-orange-600 transition-colors inline-flex items-center gap-2"
+      >
+        <Icon icon="mdi:pencil-plus" /> ไปหน้าลงทะเบียน
+      </a>
+    {/if}
+    {#if calendarUrl}
+      <a
+        href={calendarUrl}
+        target="_blank"
+        rel="noopener noreferrer"
+        class="rounded-xl border dark:border-white/10 border-slate-200 font-semibold px-5 py-2.5 hover:border-orange-500/50 transition-colors inline-flex items-center gap-2"
+      >
+        <Icon icon="mdi:calendar-month" /> ปฏิทินการศึกษา
+      </a>
+    {/if}
+  </div>
+</PageShell>

--- a/src/pages/OwnersubjwebShow.svelte
+++ b/src/pages/OwnersubjwebShow.svelte
@@ -1,0 +1,45 @@
+<script lang="ts">
+  import PageShell from "../libs/components/common/PageShell.svelte";
+  import PageHeader from "../libs/components/common/PageHeader.svelte";
+  import type { OwnersubjwebData } from "../libs/types/ownersubjweb.types";
+
+  export let semester: OwnersubjwebData["semester"] = "";
+  export let year: OwnersubjwebData["year"] = "";
+  export let headings: OwnersubjwebData["headings"] = [];
+  export let subjects: OwnersubjwebData["subjects"] = [];
+</script>
+
+<PageShell>
+  <PageHeader
+    title={`รายวิชาที่เปิดสอน ${semester}/${year}`}
+    lines={headings}
+  />
+
+  <div class="mt-4 space-y-2">
+    {#each subjects as subject (subject.code + subject.name)}
+      <a
+        href={subject.url}
+        target="_blank"
+        rel="noopener noreferrer"
+        class="flex items-center justify-between gap-4 rounded-xl border dark:border-white/10 border-slate-200 dark:bg-white/5 bg-slate-50 px-4 py-3 hover:border-orange-500/50 transition-colors"
+      >
+        <div class="min-w-0">
+          <span class="font-mono font-semibold text-orange-500"
+            >{subject.code}</span
+          >
+          <span class="ml-2 text-sm">{subject.name}</span>
+        </div>
+        <span
+          class="shrink-0 text-xs rounded-full bg-orange-500/10 text-orange-500 px-2.5 py-1"
+          >{subject.credit}</span
+        >
+      </a>
+    {/each}
+  </div>
+
+  {#if subjects.length === 0}
+    <p class="mt-6 text-center text-sm text-slate-500 dark:text-slate-400">
+      ไม่พบรายวิชา
+    </p>
+  {/if}
+</PageShell>

--- a/src/pages/TermSelectors.svelte
+++ b/src/pages/TermSelectors.svelte
@@ -14,6 +14,7 @@
     { pattern: /report_examtable/, title: "ตารางสอบ" },
     { pattern: /report_studytable/, title: "ตารางเรียน" },
     { pattern: /report_gradetable/, title: "ผลการเรียน" },
+    { pattern: /ownersubjweb/, title: "รายวิชาที่เปิดสอน" },
   ];
   $: reportTitle =
     reportTitles.find((r) => r.pattern.test(location.pathname))?.title ??


### PR DESCRIPTION
First Phase 4 batch: new registrar pages built from the current page snapshots.

## New pages
- check-regis (u_student/check_regis_no_right.php): registration eligibility card showing the registrar status message (kept in its native color), plus register and academic-calendar links.
- ownersubjweb-show (u_student/ownersubjweb_show.php): offered-subjects list with course code, name, credit, and a link to each subject page.
- ownersubjweb selector (u_student/ownersubjweb.php): reused the existing term selector by extending its route match and adding a title, so choosing a term posts to ownersubjweb_show.php.

## Details
- New scrapers (CheckRegisScraper, OwnersubjwebScraper) with unit tests over synthetic HTML (no student data).
- Registered the pages in the manifest; bumped dev to 2.5.0.
- Approach note on maintenance: only genuinely dead pages get the placeholder. Functional pages we do not reskin are left unregistered so the native page still works. This batch adds no new maintenance markings.

## Verification
- typecheck: 0 errors (1 pre-existing warning)
- eslint: 0 errors
- vitest: 25 tests pass (added ownersubjweb and check-regis scraper tests)
- Chrome and Firefox build

## Notes
- Deferred to later Phase 4 batches (need populated snapshots or are more complex): advance_gradetable (4+1, grade rows absent from snapshot), minor suite (program/apply/teachtable, some iframe/empty), payment receipt, email config and bug report forms, teachtable_v20 cascading filters, webboard/news feeds.
- Needs a live check on a logged-in reg.kmitl.ac.th session, which cannot run in CI.