### PR TITLE
Phase 4: minor program pages (home, news, curricula)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kmitl-x",
   "description": "Transform KMITL Student Information System UI/UX with enhanced features for a better experience.",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "license": "MIT",
   "type": "module",
   "scripts": {

--- a/src/libs/components/minor/MinorNav.svelte
+++ b/src/libs/components/minor/MinorNav.svelte
@@ -1,0 +1,25 @@
+<script lang="ts">
+  const links = [
+    { path: "/u_student/minor.php", label: "หน้าแรก" },
+    { path: "/u_student/minor_news.php", label: "ประกาศ" },
+    { path: "/u_student/minor_program.php", label: "หลักสูตร" },
+    { path: "/u_student/minor_apply.php", label: "สมัคร/รับสิทธิ์" },
+    { path: "/u_student/minor_teachtable.php", label: "ตารางเรียน-สอบ" },
+  ];
+
+  $: current = location.pathname;
+</script>
+
+<nav class="flex flex-wrap gap-2 mb-4 font-prompt">
+  {#each links as link (link.path)}
+    <a
+      href={location.origin + link.path}
+      class="px-4 py-2 rounded-xl text-sm font-medium transition-colors {current.endsWith(
+        link.path
+      )
+        ? 'bg-orange-500 text-white'
+        : 'border dark:border-white/10 border-slate-200 hover:border-orange-500/50 dark:text-white text-gray-900'}"
+      >{link.label}</a
+    >
+  {/each}
+</nav>

--- a/src/libs/registry/pageManifest.ts
+++ b/src/libs/registry/pageManifest.ts
@@ -91,6 +91,31 @@ export const pages: PageDefinition[] = [
     component: () => import("../../pages/CheckRegis.svelte"),
   },
   {
+    name: "minor",
+    match: /u_student\/minor\.php/,
+    scraper: () =>
+      import("../scraper/minor.scraper").then((m) => new m.MinorScraper()),
+    component: () => import("../../pages/Minor.svelte"),
+  },
+  {
+    name: "minor-news",
+    match: /u_student\/minor_news\.php/,
+    scraper: () =>
+      import("../scraper/minor-news.scraper").then(
+        (m) => new m.MinorNewsScraper()
+      ),
+    component: () => import("../../pages/MinorNews.svelte"),
+  },
+  {
+    name: "minor-program",
+    match: /u_student\/minor_program\.php/,
+    scraper: () =>
+      import("../scraper/minor-program.scraper").then(
+        (m) => new m.MinorProgramScraper()
+      ),
+    component: () => import("../../pages/MinorProgram.svelte"),
+  },
+  {
     // static image page, kept as a placeholder rather than reskinned
     name: "grade-process",
     match: /u_student\/grade_process\.php/,

--- a/src/libs/scraper/minor-news.scraper.test.ts
+++ b/src/libs/scraper/minor-news.scraper.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from "vitest";
+import { MinorNewsScraper } from "./minor-news.scraper";
+
+describe("MinorNewsScraper", () => {
+  it("extracts title, view count, and date", async () => {
+    const html = `
+      <table><tbody>
+        <tr><td>&nbsp;<a href="https://x/index/group_news.php?group=23&date=2025-09-03">(2) <strong>ประกาศรับสมัคร</strong></a>[26]<font color="#CCCCCC">[3 ก.ย. 68 - 10:29 น.]</font></td></tr>
+      </tbody></table>`;
+    const doc = new DOMParser().parseFromString(html, "text/html");
+    const r = await new MinorNewsScraper().scrape(doc);
+
+    expect(r.news).toHaveLength(1);
+    expect(r.news[0].title).toBe("ประกาศรับสมัคร");
+    expect(r.news[0].count).toBe(26);
+    expect(r.news[0].url).toContain("group_news.php");
+    expect(r.news[0].date).toContain("3 ก.ย. 68");
+  });
+});

--- a/src/libs/scraper/minor-news.scraper.ts
+++ b/src/libs/scraper/minor-news.scraper.ts
@@ -18,7 +18,11 @@ export class MinorNewsScraper extends BaseScraper {
       const cell = link.closest("td");
       const dateText =
         cell?.querySelector('font[color="#CCCCCC"]')?.textContent || "";
-      const date = dateText.replace(/[[\]]/g, "").replace(/\s+/g, " ").trim();
+      // The date sits inside square brackets, e.g. "[3 ก.ย. 68 - 10:29 น.]".
+      const insideBrackets = dateText.match(/\[(.*)\]/);
+      const date = (insideBrackets ? insideBrackets[1] : dateText)
+        .replace(/\s+/g, " ")
+        .trim();
 
       // The view count is the numeric bracket after the link, e.g. [10].
       const countMatch = (cell?.textContent || "").match(/\[(\d+)\]/);

--- a/src/libs/scraper/minor-news.scraper.ts
+++ b/src/libs/scraper/minor-news.scraper.ts
@@ -1,0 +1,32 @@
+import type { MinorNewsData, MinorNewsItem } from "../types/minor-news.types";
+import { BaseScraper } from "./baseScraper";
+import { getStudentHeader } from "../utils/studentHeader";
+
+export class MinorNewsScraper extends BaseScraper {
+  public async scrape(document: Document): Promise<MinorNewsData> {
+    const links = Array.from(
+      document.querySelectorAll<HTMLAnchorElement>('a[href*="group_news.php"]')
+    );
+
+    const news: MinorNewsItem[] = links.map((link) => {
+      // Titles are prefixed with a row number like "(2) "; drop it.
+      const title = (link.textContent || "")
+        .replace(/\s+/g, " ")
+        .replace(/^\(\d+\)\s*/, "")
+        .trim();
+
+      const cell = link.closest("td");
+      const dateText =
+        cell?.querySelector('font[color="#CCCCCC"]')?.textContent || "";
+      const date = dateText.replace(/[[\]]/g, "").replace(/\s+/g, " ").trim();
+
+      // The view count is the numeric bracket after the link, e.g. [10].
+      const countMatch = (cell?.textContent || "").match(/\[(\d+)\]/);
+      const count = countMatch ? parseInt(countMatch[1], 10) : 0;
+
+      return { title, url: link.href, count, date };
+    });
+
+    return { ...getStudentHeader(document), news };
+  }
+}

--- a/src/libs/scraper/minor-program.scraper.test.ts
+++ b/src/libs/scraper/minor-program.scraper.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from "vitest";
+import { MinorProgramScraper } from "./minor-program.scraper";
+
+describe("MinorProgramScraper", () => {
+  it("groups programs under their category", async () => {
+    const html = `
+      <table><tbody>
+        <tr><td align="center"><b>คณะวิศวกรรมศาสตร์</b></td></tr>
+        <tr><td><a href="https://x/curriculum/file/minor/1.AI.pdf">AI</a></td></tr>
+        <tr><td><a href="https://x/curriculum/file/minor/2.EM.pdf">EM</a></td></tr>
+        <tr><td align="center"><b>คณะวิทยาศาสตร์</b></td></tr>
+        <tr><td><a href="https://x/curriculum/file/minor/3.Ins.pdf">Insurance</a></td></tr>
+      </tbody></table>`;
+    const doc = new DOMParser().parseFromString(html, "text/html");
+    const r = await new MinorProgramScraper().scrape(doc);
+
+    expect(r.categories).toHaveLength(2);
+    expect(r.categories[0].category).toBe("คณะวิศวกรรมศาสตร์");
+    expect(r.categories[0].items).toHaveLength(2);
+    expect(r.categories[0].items[0]).toEqual({
+      name: "AI",
+      url: "https://x/curriculum/file/minor/1.AI.pdf",
+    });
+    expect(r.categories[1].items).toHaveLength(1);
+  });
+});

--- a/src/libs/scraper/minor-program.scraper.ts
+++ b/src/libs/scraper/minor-program.scraper.ts
@@ -1,0 +1,44 @@
+import type {
+  MinorProgramCategory,
+  MinorProgramData,
+} from "../types/minor-program.types";
+import { BaseScraper } from "./baseScraper";
+import { getStudentHeader } from "../utils/studentHeader";
+
+export class MinorProgramScraper extends BaseScraper {
+  public async scrape(document: Document): Promise<MinorProgramData> {
+    // Walk cells in order. A bold cell with no link starts a new category; a
+    // cell with a minor curriculum PDF link is a program under that category.
+    const categories: MinorProgramCategory[] = [];
+    let current: MinorProgramCategory | null = null;
+
+    for (const cell of Array.from(document.querySelectorAll("td"))) {
+      const link = cell.querySelector<HTMLAnchorElement>(
+        'a[href*="curriculum/file/minor"]'
+      );
+      if (link) {
+        const name = (link.textContent || "").replace(/\s+/g, " ").trim();
+        if (!current) {
+          current = { category: "", items: [] };
+          categories.push(current);
+        }
+        current.items.push({ name, url: link.href });
+        continue;
+      }
+
+      const bold = cell.querySelector("b");
+      if (bold && !cell.querySelector("a")) {
+        const category = (bold.textContent || "").replace(/\s+/g, " ").trim();
+        if (category) {
+          current = { category, items: [] };
+          categories.push(current);
+        }
+      }
+    }
+
+    return {
+      ...getStudentHeader(document),
+      categories: categories.filter((category) => category.items.length > 0),
+    };
+  }
+}

--- a/src/libs/scraper/minor.scraper.test.ts
+++ b/src/libs/scraper/minor.scraper.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from "vitest";
+import { MinorScraper } from "./minor.scraper";
+
+describe("MinorScraper", () => {
+  it("extracts events from #tb1 and the student header", async () => {
+    const html = `
+      <div id="div_student_id">&nbsp;68010488</div>
+      <div id="div_tname">&nbsp;First&nbsp;&nbsp;Last</div>
+      <table id="tb1"><tbody>
+        <tr><td bgcolor="#CCCCCC"><strong>รายละเอียด</strong></td><td bgcolor="#CCCCCC"><strong>กำหนดการ</strong></td></tr>
+        <tr><td>รับสมัคร</td><td>20 - 27</td></tr>
+        <tr><td>สอบ</td><td>29</td></tr>
+      </tbody></table>`;
+    const doc = new DOMParser().parseFromString(html, "text/html");
+    const r = await new MinorScraper().scrape(doc);
+
+    expect(r.studentId).toBe("68010488");
+    expect(r.name).toBe("First Last");
+    expect(r.events).toHaveLength(2);
+    expect(r.events[0]).toEqual({ description: "รับสมัคร", schedule: "20 - 27" });
+  });
+});

--- a/src/libs/scraper/minor.scraper.ts
+++ b/src/libs/scraper/minor.scraper.ts
@@ -1,0 +1,22 @@
+import type { MinorData, MinorEvent } from "../types/minor.types";
+import { BaseScraper } from "./baseScraper";
+import { getStudentHeader } from "../utils/studentHeader";
+
+export class MinorScraper extends BaseScraper {
+  public async scrape(document: Document): Promise<MinorData> {
+    // The schedule table #tb1 has a header row followed by description/date rows.
+    const rows = Array.from(document.querySelectorAll("#tb1 tr")).slice(1);
+
+    const events: MinorEvent[] = rows
+      .map((row) => {
+        const cells = Array.from(row.querySelectorAll("td"));
+        return {
+          description: (cells[0]?.textContent || "").replace(/\s+/g, " ").trim(),
+          schedule: (cells[1]?.textContent || "").replace(/\s+/g, " ").trim(),
+        };
+      })
+      .filter((event) => event.description || event.schedule);
+
+    return { ...getStudentHeader(document), events };
+  }
+}

--- a/src/libs/types/minor-news.types.ts
+++ b/src/libs/types/minor-news.types.ts
@@ -1,0 +1,12 @@
+export interface MinorNewsItem {
+  title: string;
+  url: string;
+  count: number;
+  date: string;
+}
+
+export interface MinorNewsData {
+  studentId: string;
+  name: string;
+  news: MinorNewsItem[];
+}

--- a/src/libs/types/minor-program.types.ts
+++ b/src/libs/types/minor-program.types.ts
@@ -1,0 +1,15 @@
+export interface MinorProgramItem {
+  name: string;
+  url: string;
+}
+
+export interface MinorProgramCategory {
+  category: string;
+  items: MinorProgramItem[];
+}
+
+export interface MinorProgramData {
+  studentId: string;
+  name: string;
+  categories: MinorProgramCategory[];
+}

--- a/src/libs/types/minor.types.ts
+++ b/src/libs/types/minor.types.ts
@@ -1,0 +1,10 @@
+export interface MinorEvent {
+  description: string;
+  schedule: string;
+}
+
+export interface MinorData {
+  studentId: string;
+  name: string;
+  events: MinorEvent[];
+}

--- a/src/libs/utils/studentHeader.ts
+++ b/src/libs/utils/studentHeader.ts
@@ -1,0 +1,16 @@
+// Several registrar pages expose the logged-in student in the same two divs.
+export function getDivText(document: Document, id: string): string {
+  return (document.getElementById(id)?.textContent || "")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+export function getStudentHeader(document: Document): {
+  studentId: string;
+  name: string;
+} {
+  return {
+    studentId: getDivText(document, "div_student_id"),
+    name: getDivText(document, "div_tname"),
+  };
+}

--- a/src/pages/Minor.svelte
+++ b/src/pages/Minor.svelte
@@ -1,0 +1,44 @@
+<script lang="ts">
+  import PageShell from "../libs/components/common/PageShell.svelte";
+  import PageHeader from "../libs/components/common/PageHeader.svelte";
+  import MinorNav from "../libs/components/minor/MinorNav.svelte";
+  import type { MinorData } from "../libs/types/minor.types";
+
+  export let studentId: MinorData["studentId"] = "";
+  export let name: MinorData["name"] = "";
+  export let events: MinorData["events"] = [];
+</script>
+
+<PageShell>
+  <MinorNav />
+  <PageHeader title="หลักสูตรวิชาโท" lines={[`${studentId} ${name}`]} />
+
+  <div
+    class="mt-4 overflow-x-auto rounded-2xl border dark:border-white/10 border-slate-200"
+  >
+    <table class="w-full text-sm">
+      <thead
+        class="dark:bg-white/5 bg-slate-100 text-slate-500 dark:text-slate-400"
+      >
+        <tr>
+          <th class="px-4 py-2 text-left font-medium">รายละเอียด</th>
+          <th class="px-4 py-2 text-left font-medium">กำหนดการ</th>
+        </tr>
+      </thead>
+      <tbody>
+        {#each events as event, i (event.description + i)}
+          <tr class="border-t dark:border-white/10 border-slate-200">
+            <td class="px-4 py-2">{event.description}</td>
+            <td class="px-4 py-2">{event.schedule}</td>
+          </tr>
+        {/each}
+      </tbody>
+    </table>
+  </div>
+
+  {#if events.length === 0}
+    <p class="mt-4 text-center text-sm text-slate-500 dark:text-slate-400">
+      ไม่พบข้อมูลกำหนดการ
+    </p>
+  {/if}
+</PageShell>

--- a/src/pages/MinorNews.svelte
+++ b/src/pages/MinorNews.svelte
@@ -1,0 +1,46 @@
+<script lang="ts">
+  import PageShell from "../libs/components/common/PageShell.svelte";
+  import PageHeader from "../libs/components/common/PageHeader.svelte";
+  import MinorNav from "../libs/components/minor/MinorNav.svelte";
+  import Icon from "@iconify/svelte";
+  import type { MinorNewsData } from "../libs/types/minor-news.types";
+
+  export let studentId: MinorNewsData["studentId"] = "";
+  export let name: MinorNewsData["name"] = "";
+  export let news: MinorNewsData["news"] = [];
+</script>
+
+<PageShell>
+  <MinorNav />
+  <PageHeader title="ประกาศหลักสูตรวิชาโท" lines={[`${studentId} ${name}`]} />
+
+  <div class="mt-4 space-y-2">
+    {#each news as item, i (item.url + i)}
+      <a
+        href={item.url}
+        target="_blank"
+        rel="noopener noreferrer"
+        class="flex items-center justify-between gap-4 rounded-xl border dark:border-white/10 border-slate-200 dark:bg-white/5 bg-slate-50 px-4 py-3 hover:border-orange-500/50 transition-colors"
+      >
+        <div class="min-w-0">
+          <p class="text-sm font-medium truncate">{item.title}</p>
+          {#if item.date}
+            <p class="text-xs text-slate-400 mt-0.5">{item.date}</p>
+          {/if}
+        </div>
+        <span
+          class="shrink-0 inline-flex items-center gap-1 text-xs text-slate-500 dark:text-slate-400"
+        >
+          <Icon icon="mdi:eye-outline" />
+          {item.count}
+        </span>
+      </a>
+    {/each}
+  </div>
+
+  {#if news.length === 0}
+    <p class="mt-4 text-center text-sm text-slate-500 dark:text-slate-400">
+      ไม่พบประกาศ
+    </p>
+  {/if}
+</PageShell>

--- a/src/pages/MinorProgram.svelte
+++ b/src/pages/MinorProgram.svelte
@@ -1,0 +1,50 @@
+<script lang="ts">
+  import PageShell from "../libs/components/common/PageShell.svelte";
+  import PageHeader from "../libs/components/common/PageHeader.svelte";
+  import MinorNav from "../libs/components/minor/MinorNav.svelte";
+  import Icon from "@iconify/svelte";
+  import type { MinorProgramData } from "../libs/types/minor-program.types";
+
+  export let studentId: MinorProgramData["studentId"] = "";
+  export let name: MinorProgramData["name"] = "";
+  export let categories: MinorProgramData["categories"] = [];
+</script>
+
+<PageShell>
+  <MinorNav />
+  <PageHeader title="หลักสูตรวิชาโท" lines={[`${studentId} ${name}`]} />
+
+  <div class="mt-4 space-y-4">
+    {#each categories as cat, ci (cat.category + ci)}
+      <div>
+        {#if cat.category}
+          <h2 class="text-sm font-semibold text-orange-500 mb-2">
+            {cat.category}
+          </h2>
+        {/if}
+        <div class="grid gap-2 sm:grid-cols-2">
+          {#each cat.items as item, ii (item.url + ii)}
+            <a
+              href={item.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              class="flex items-center gap-3 rounded-xl border dark:border-white/10 border-slate-200 dark:bg-white/5 bg-slate-50 px-4 py-3 hover:border-orange-500/50 transition-colors"
+            >
+              <Icon
+                icon="ph:file-pdf-light"
+                class="text-2xl text-orange-500 shrink-0"
+              />
+              <span class="text-sm">{item.name}</span>
+            </a>
+          {/each}
+        </div>
+      </div>
+    {/each}
+  </div>
+
+  {#if categories.length === 0}
+    <p class="mt-4 text-center text-sm text-slate-500 dark:text-slate-400">
+      ไม่พบหลักสูตร
+    </p>
+  {/if}
+</PageShell>


### PR DESCRIPTION
Second Phase 4 batch: reskin the minor-program section.

## New pages
- minor (u_student/minor.php): student header, shared minor nav, and the key-dates schedule table.
- minor-news (u_student/minor_news.php): announcement feed with title, date, and view count.
- minor-program (u_student/minor_program.php): curriculum PDFs grouped by faculty category.

## Shared
- MinorNav component across the minor pages (active tab from the current path).
- getStudentHeader helper for the common #div_student_id / #div_tname header.

## Details
- New scrapers (MinorScraper, MinorNewsScraper, MinorProgramScraper) with unit tests over synthetic HTML (no student data). 28 tests total.
- Registered the pages in the manifest; bumped dev to 2.5.1.

## Verification
- typecheck: 0 errors (1 pre-existing warning)
- eslint: 0 errors
- vitest: 28 tests pass
- Chrome and Firefox build

## Deferred (native pages still work)
- minor_apply: the program table is empty in the snapshot, so the row structure is unverified.
- minor_teachtable: the schedule loads inside an iframe, which needs a different scraping approach.
- Needs a live check on a logged-in reg.kmitl.ac.th session, which cannot run in CI.