### PR TITLE
Phase 4: payment receipt and email settings pages

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kmitl-x",
   "description": "Transform KMITL Student Information System UI/UX with enhanced features for a better experience.",
-  "version": "2.5.2",
+  "version": "2.5.3",
   "license": "MIT",
   "type": "module",
   "scripts": {

--- a/src/libs/registry/pageManifest.ts
+++ b/src/libs/registry/pageManifest.ts
@@ -116,6 +116,24 @@ export const pages: PageDefinition[] = [
     component: () => import("../../pages/MinorProgram.svelte"),
   },
   {
+    name: "payment-receipt",
+    match: /payment\/print_receipt\.php/,
+    scraper: () =>
+      import("../scraper/payment-receipt.scraper").then(
+        (m) => new m.PaymentReceiptScraper()
+      ),
+    component: () => import("../../pages/PaymentReceipt.svelte"),
+  },
+  {
+    name: "email-config",
+    match: /u_student\/email_config\.php/,
+    scraper: () =>
+      import("../scraper/email-config.scraper").then(
+        (m) => new m.EmailConfigScraper()
+      ),
+    component: () => import("../../pages/EmailConfig.svelte"),
+  },
+  {
     // static image page, kept as a placeholder rather than reskinned
     name: "grade-process",
     match: /u_student\/grade_process\.php/,

--- a/src/libs/scraper/email-config.scraper.test.ts
+++ b/src/libs/scraper/email-config.scraper.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from "vitest";
+import { EmailConfigScraper } from "./email-config.scraper";
+
+describe("EmailConfigScraper", () => {
+  it("extracts options, the current choice, and the session token", async () => {
+    const html = `
+      <form>
+        <table><tbody>
+          <tr>
+            <td><div>ต้องการแจ้งประกาศผลเกรด :</div></td>
+            <td>
+              <label><input name="group0" type="radio" value="1" checked> รับ</label>
+              <label><input name="group0" type="radio" value="2"> ไม่รับ</label>
+            </td>
+          </tr>
+        </tbody></table>
+        <input name="ssid" type="hidden" id="ssid" value="abc123">
+      </form>`;
+    const doc = new DOMParser().parseFromString(html, "text/html");
+    const r = await new EmailConfigScraper().scrape(doc);
+
+    expect(r.options).toHaveLength(2);
+    expect(r.options[0]).toEqual({ value: "1", label: "รับ" });
+    expect(r.options[1].value).toBe("2");
+    expect(r.selected).toBe("1");
+    expect(r.ssid).toBe("abc123");
+    expect(r.question).toContain("ต้องการแจ้งประกาศผลเกรด");
+  });
+});

--- a/src/libs/scraper/email-config.scraper.ts
+++ b/src/libs/scraper/email-config.scraper.ts
@@ -1,0 +1,39 @@
+import type {
+  EmailConfigData,
+  EmailConfigOption,
+} from "../types/email-config.types";
+import { BaseScraper } from "./baseScraper";
+
+export class EmailConfigScraper extends BaseScraper {
+  public async scrape(document: Document): Promise<EmailConfigData> {
+    const radios = Array.from(
+      document.querySelectorAll<HTMLInputElement>('input[name="group0"]')
+    );
+
+    const options: EmailConfigOption[] = radios.map((radio) => {
+      const label = (
+        radio.closest("label")?.textContent ||
+        radio.parentElement?.textContent ||
+        ""
+      )
+        .replace(/\s+/g, " ")
+        .trim();
+      return { value: radio.value, label };
+    });
+
+    const selected =
+      radios.find((r) => r.checked)?.value || options[0]?.value || "";
+
+    const ssid =
+      document.querySelector<HTMLInputElement>('#ssid, input[name="ssid"]')
+        ?.value || "";
+
+    const question = (
+      radios[0]?.closest("tr")?.querySelector("td")?.textContent || ""
+    )
+      .replace(/\s+/g, " ")
+      .trim();
+
+    return { question, options, selected, ssid };
+  }
+}

--- a/src/libs/scraper/payment-receipt.scraper.test.ts
+++ b/src/libs/scraper/payment-receipt.scraper.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from "vitest";
+import { PaymentReceiptScraper } from "./payment-receipt.scraper";
+
+describe("PaymentReceiptScraper", () => {
+  it("extracts term options, records, and documents", async () => {
+    const html = `
+      <form>
+        <select id="year" name="year"><option value="2569" selected>2569</option><option value="2568">2568</option></select>
+        <select id="semester" name="semester"><option value="1" selected>1</option></select>
+      </form>
+      <table width="599"><tbody>
+        <tr align="center"><td bgcolor="#E1E1E1"><strong>student-id</strong></td><td bgcolor="#E1E1E1">name</td></tr>
+        <tr align="center">
+          <td bgcolor="#FBFCDE">68010488</td>
+          <td bgcolor="#FBFCDE">First Last</td>
+          <td bgcolor="#FBFCDE">-</td>
+          <td bgcolor="#FBFCDE">-</td>
+          <td bgcolor="#FBFCDE">ยังไม่ได้ร้องขอ</td>
+        </tr>
+      </tbody></table>
+      <table width="750"><tbody>
+        <tr bgcolor="#FDF3E7">
+          <td><a href="http://x/files/fee.pdf">อัตราค่าธรรมเนียม</a></td>
+          <td><a href="http://x/files/fee.pdf"><img src="pdf16.gif"></a></td>
+        </tr>
+      </tbody></table>`;
+    const doc = new DOMParser().parseFromString(html, "text/html");
+    const r = await new PaymentReceiptScraper().scrape(doc);
+
+    expect(r.yearOptions).toEqual(["2569", "2568"]);
+    expect(r.selectedYear).toBe("2569");
+    expect(r.selectedSemester).toBe("1");
+    expect(r.records).toHaveLength(1);
+    expect(r.records[0].studentId).toBe("68010488");
+    expect(r.records[0].status).toBe("ยังไม่ได้ร้องขอ");
+    expect(r.documents).toHaveLength(1);
+    expect(r.documents[0].name).toBe("อัตราค่าธรรมเนียม");
+    expect(r.documents[0].url).toContain("fee.pdf");
+  });
+});

--- a/src/libs/scraper/payment-receipt.scraper.test.ts
+++ b/src/libs/scraper/payment-receipt.scraper.test.ts
@@ -23,6 +23,14 @@ describe("PaymentReceiptScraper", () => {
           <td><a href="http://x/files/fee.pdf">อัตราค่าธรรมเนียม</a></td>
           <td><a href="http://x/files/fee.pdf"><img src="pdf16.gif"></a></td>
         </tr>
+        <tr bgcolor="#FDF3E7">
+          <td><a href="http://x/files/form.pdf">แบบฟอร์ม</a></td>
+          <td><a href="http://x/files/form.pdf"><img src="pdf16.gif"></a></td>
+        </tr>
+        <tr bgcolor="#ECECEC">
+          <td><a href="http://x/files/fee.pdf">อัตราค่าธรรมเนียม (ซ้ำ)</a></td>
+          <td><a href="http://x/files/fee.pdf"><img src="pdf16.gif"></a></td>
+        </tr>
       </tbody></table>`;
     const doc = new DOMParser().parseFromString(html, "text/html");
     const r = await new PaymentReceiptScraper().scrape(doc);
@@ -33,8 +41,12 @@ describe("PaymentReceiptScraper", () => {
     expect(r.records).toHaveLength(1);
     expect(r.records[0].studentId).toBe("68010488");
     expect(r.records[0].status).toBe("ยังไม่ได้ร้องขอ");
-    expect(r.documents).toHaveLength(1);
+    // fee.pdf appears twice but is de-duplicated
+    expect(r.documents).toHaveLength(2);
+    expect(r.documents.map((d) => d.url)).toEqual([
+      "http://x/files/fee.pdf",
+      "http://x/files/form.pdf",
+    ]);
     expect(r.documents[0].name).toBe("อัตราค่าธรรมเนียม");
-    expect(r.documents[0].url).toContain("fee.pdf");
   });
 });

--- a/src/libs/scraper/payment-receipt.scraper.test.ts
+++ b/src/libs/scraper/payment-receipt.scraper.test.ts
@@ -13,9 +13,9 @@ describe("PaymentReceiptScraper", () => {
         <tr align="center">
           <td bgcolor="#FBFCDE">68010488</td>
           <td bgcolor="#FBFCDE">First Last</td>
-          <td bgcolor="#FBFCDE">-</td>
-          <td bgcolor="#FBFCDE">-</td>
-          <td bgcolor="#FBFCDE">ยังไม่ได้ร้องขอ</td>
+          <td bgcolor="#FBFCDE">2025-11-02</td>
+          <td bgcolor="#FBFCDE">2025-11-02</td>
+          <td bgcolor="#FBFCDE"><a href="http://x/payment/billstd_v2_pdf.php?student_id=68010488&year=2568&semester=1"><img src="bill.png"></a></td>
         </tr>
       </tbody></table>
       <table width="750"><tbody>
@@ -40,7 +40,7 @@ describe("PaymentReceiptScraper", () => {
     expect(r.selectedSemester).toBe("1");
     expect(r.records).toHaveLength(1);
     expect(r.records[0].studentId).toBe("68010488");
-    expect(r.records[0].status).toBe("ยังไม่ได้ร้องขอ");
+    expect(r.records[0].receiptUrl).toContain("billstd_v2_pdf");
     // fee.pdf appears twice but is de-duplicated
     expect(r.documents).toHaveLength(2);
     expect(r.documents.map((d) => d.url)).toEqual([

--- a/src/libs/scraper/payment-receipt.scraper.ts
+++ b/src/libs/scraper/payment-receipt.scraper.ts
@@ -44,18 +44,21 @@ export class PaymentReceiptScraper extends BaseScraper {
       .filter((r) => r.studentId || r.name);
 
     // Fee documents: rows with a PDF link. Name is the first link, the download
-    // is the last link (the icon column).
-    const documents: FeeDocument[] = Array.from(document.querySelectorAll("tr"))
-      .filter((row) => row.querySelector('a[href$=".pdf"]'))
-      .map((row) => {
-        const links = Array.from(
-          row.querySelectorAll<HTMLAnchorElement>('a[href$=".pdf"]')
-        );
-        const name = (links[0]?.textContent || "").replace(/\s+/g, " ").trim();
-        const url = links[links.length - 1]?.href || links[0]?.href || "";
-        return { name: name || "เอกสาร", url };
-      })
-      .filter((d) => d.url);
+    // is the last link (the icon column). The registrar lists some files in
+    // more than one row, so de-duplicate by URL.
+    const documents: FeeDocument[] = [];
+    const seen = new Set<string>();
+    for (const row of Array.from(document.querySelectorAll("tr"))) {
+      const links = Array.from(
+        row.querySelectorAll<HTMLAnchorElement>('a[href$=".pdf"]')
+      );
+      if (links.length === 0) continue;
+      const url = links[links.length - 1]?.href || links[0]?.href || "";
+      if (!url || seen.has(url)) continue;
+      seen.add(url);
+      const name = (links[0]?.textContent || "").replace(/\s+/g, " ").trim();
+      documents.push({ name: name || "เอกสาร", url });
+    }
 
     return {
       yearOptions: optionValues(yearSelect),

--- a/src/libs/scraper/payment-receipt.scraper.ts
+++ b/src/libs/scraper/payment-receipt.scraper.ts
@@ -30,15 +30,18 @@ export class PaymentReceiptScraper extends BaseScraper {
           !!row.querySelector('td[bgcolor="#FBFCDE"]')
       )
       .map((row) => {
-        const c = Array.from(row.querySelectorAll("td")).map((td) =>
-          (td.textContent || "").replace(/\s+/g, " ").trim()
-        );
+        const cells = Array.from(row.querySelectorAll("td"));
+        const text = (i: number) =>
+          (cells[i]?.textContent || "").replace(/\s+/g, " ").trim();
+        // The last cell is a download link when the receipt is available.
+        const link = cells[4]?.querySelector<HTMLAnchorElement>("a[href]");
         return {
-          studentId: c[0] || "",
-          name: c[1] || "",
-          requestedDate: c[2] || "",
-          approvedDate: c[3] || "",
-          status: c[4] || "",
+          studentId: text(0),
+          name: text(1),
+          requestedDate: text(2),
+          approvedDate: text(3),
+          status: text(4),
+          receiptUrl: link?.href || "",
         };
       })
       .filter((r) => r.studentId || r.name);

--- a/src/libs/scraper/payment-receipt.scraper.ts
+++ b/src/libs/scraper/payment-receipt.scraper.ts
@@ -1,0 +1,69 @@
+import type {
+  FeeDocument,
+  PaymentReceiptData,
+  ReceiptRecord,
+} from "../types/payment-receipt.types";
+import { BaseScraper } from "./baseScraper";
+
+export class PaymentReceiptScraper extends BaseScraper {
+  public async scrape(document: Document): Promise<PaymentReceiptData> {
+    const yearSelect = document.querySelector<HTMLSelectElement>(
+      "#year, select[name='year']"
+    );
+    const semesterSelect = document.querySelector<HTMLSelectElement>(
+      "#semester, select[name='semester']"
+    );
+    const optionValues = (select: HTMLSelectElement | null) =>
+      select
+        ? Array.from(select.querySelectorAll<HTMLOptionElement>("option")).map(
+            (o) => o.value
+          )
+        : [];
+
+    // Request records live in rows shaded #FBFCDE, five cells each.
+    const records: ReceiptRecord[] = Array.from(
+      document.querySelectorAll("tr")
+    )
+      .filter(
+        (row) =>
+          (row.getAttribute("bgcolor") || "").toUpperCase() === "#FBFCDE" ||
+          !!row.querySelector('td[bgcolor="#FBFCDE"]')
+      )
+      .map((row) => {
+        const c = Array.from(row.querySelectorAll("td")).map((td) =>
+          (td.textContent || "").replace(/\s+/g, " ").trim()
+        );
+        return {
+          studentId: c[0] || "",
+          name: c[1] || "",
+          requestedDate: c[2] || "",
+          approvedDate: c[3] || "",
+          status: c[4] || "",
+        };
+      })
+      .filter((r) => r.studentId || r.name);
+
+    // Fee documents: rows with a PDF link. Name is the first link, the download
+    // is the last link (the icon column).
+    const documents: FeeDocument[] = Array.from(document.querySelectorAll("tr"))
+      .filter((row) => row.querySelector('a[href$=".pdf"]'))
+      .map((row) => {
+        const links = Array.from(
+          row.querySelectorAll<HTMLAnchorElement>('a[href$=".pdf"]')
+        );
+        const name = (links[0]?.textContent || "").replace(/\s+/g, " ").trim();
+        const url = links[links.length - 1]?.href || links[0]?.href || "";
+        return { name: name || "เอกสาร", url };
+      })
+      .filter((d) => d.url);
+
+    return {
+      yearOptions: optionValues(yearSelect),
+      semesterOptions: optionValues(semesterSelect),
+      selectedYear: yearSelect?.value || "",
+      selectedSemester: semesterSelect?.value || "",
+      records,
+      documents,
+    };
+  }
+}

--- a/src/libs/types/email-config.types.ts
+++ b/src/libs/types/email-config.types.ts
@@ -1,0 +1,11 @@
+export interface EmailConfigOption {
+  value: string;
+  label: string;
+}
+
+export interface EmailConfigData {
+  question: string;
+  options: EmailConfigOption[];
+  selected: string;
+  ssid: string;
+}

--- a/src/libs/types/payment-receipt.types.ts
+++ b/src/libs/types/payment-receipt.types.ts
@@ -1,0 +1,21 @@
+export interface ReceiptRecord {
+  studentId: string;
+  name: string;
+  requestedDate: string;
+  approvedDate: string;
+  status: string;
+}
+
+export interface FeeDocument {
+  name: string;
+  url: string;
+}
+
+export interface PaymentReceiptData {
+  yearOptions: string[];
+  semesterOptions: string[];
+  selectedYear: string;
+  selectedSemester: string;
+  records: ReceiptRecord[];
+  documents: FeeDocument[];
+}

--- a/src/libs/types/payment-receipt.types.ts
+++ b/src/libs/types/payment-receipt.types.ts
@@ -4,6 +4,8 @@ export interface ReceiptRecord {
   requestedDate: string;
   approvedDate: string;
   status: string;
+  // When the receipt is available, the request/print column is a download link.
+  receiptUrl: string;
 }
 
 export interface FeeDocument {

--- a/src/libs/utils/formSubmit.ts
+++ b/src/libs/utils/formSubmit.ts
@@ -1,0 +1,23 @@
+// Mirror a native registrar form: POST the given fields and let the browser
+// navigate, where the extension reskins the result. Used by pages that submit
+// (term/receipt selectors, settings forms).
+export function submitForm(
+  action: string,
+  fields: Record<string, string>,
+  enctype = "multipart/form-data"
+): void {
+  const form = document.createElement("form");
+  form.method = "post";
+  form.action = action;
+  form.enctype = enctype;
+  for (const [name, value] of Object.entries(fields)) {
+    const input = document.createElement("input");
+    input.type = "hidden";
+    input.name = name;
+    input.value = value;
+    form.appendChild(input);
+  }
+  document.body.appendChild(form);
+  form.submit();
+  form.remove();
+}

--- a/src/pages/EmailConfig.svelte
+++ b/src/pages/EmailConfig.svelte
@@ -1,0 +1,61 @@
+<script lang="ts">
+  import PageShell from "../libs/components/common/PageShell.svelte";
+  import PageHeader from "../libs/components/common/PageHeader.svelte";
+  import { submitForm } from "../libs/utils/formSubmit";
+  import type { EmailConfigData } from "../libs/types/email-config.types";
+
+  export let question: EmailConfigData["question"] = "";
+  export let options: EmailConfigData["options"] = [];
+  export let selected: EmailConfigData["selected"] = "";
+  export let ssid: EmailConfigData["ssid"] = "";
+
+  let choice = selected;
+  let saving = false;
+
+  // Mirror the native form: POST the choice and session token, then the page
+  // reloads with the saved state.
+  function save() {
+    saving = true;
+    submitForm(location.origin + location.pathname, {
+      group0: choice,
+      ssid,
+      Submit: "บันทึก",
+    });
+  }
+</script>
+
+<PageShell>
+  <PageHeader title="ตั้งค่าการรับอีเมล" lines={[]} />
+
+  <div
+    class="mt-4 max-w-lg mx-auto rounded-2xl border dark:border-white/10 border-slate-200 dark:bg-white/5 bg-slate-50 p-6"
+  >
+    {#if question}
+      <p class="text-sm text-slate-600 dark:text-slate-300 mb-3">{question}</p>
+    {/if}
+
+    <div class="space-y-2">
+      {#each options as opt (opt.value)}
+        <label
+          class="flex items-center gap-3 rounded-xl border dark:border-white/10 border-slate-200 px-4 py-2.5 cursor-pointer hover:border-orange-500/50 transition-colors"
+        >
+          <input
+            type="radio"
+            bind:group={choice}
+            value={opt.value}
+            class="accent-orange-500"
+          />
+          <span class="text-sm">{opt.label}</span>
+        </label>
+      {/each}
+    </div>
+
+    <button
+      on:click={save}
+      disabled={saving || !ssid}
+      class="mt-4 w-full rounded-xl bg-orange-500 text-white font-semibold py-2.5 hover:bg-orange-600 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+    >
+      บันทึก
+    </button>
+  </div>
+</PageShell>

--- a/src/pages/EmailConfig.svelte
+++ b/src/pages/EmailConfig.svelte
@@ -41,6 +41,7 @@
         >
           <input
             type="radio"
+            name="group0"
             bind:group={choice}
             value={opt.value}
             class="accent-orange-500"

--- a/src/pages/GradeReport.svelte
+++ b/src/pages/GradeReport.svelte
@@ -45,7 +45,7 @@
         </tr>
       </thead>
       <tbody>
-        {#each gradeTable as row (row.subjectCode + row.section)}
+        {#each gradeTable as row, i (row.subjectCode + "-" + i)}
           <tr class="border-t dark:border-white/10 border-slate-200">
             <td class="px-3 py-2 font-medium text-orange-500">
               {row.subjectCode}

--- a/src/pages/MidtermScore.svelte
+++ b/src/pages/MidtermScore.svelte
@@ -37,7 +37,7 @@
         </tr>
       </thead>
       <tbody>
-        {#each midtermScores as subject (subject.subjectCode + subject.section)}
+        {#each midtermScores as subject, i (subject.subjectCode + "-" + i)}
           <tr class="border-t dark:border-white/10 border-slate-200">
             <td class="px-3 py-2 font-medium text-orange-500">
               {subject.subjectCode}

--- a/src/pages/OwnersubjwebShow.svelte
+++ b/src/pages/OwnersubjwebShow.svelte
@@ -16,7 +16,7 @@
   />
 
   <div class="mt-4 space-y-2">
-    {#each subjects as subject (subject.code + subject.name)}
+    {#each subjects as subject, i (subject.code + "-" + i)}
       <a
         href={subject.url}
         target="_blank"

--- a/src/pages/PaymentReceipt.svelte
+++ b/src/pages/PaymentReceipt.svelte
@@ -60,7 +60,21 @@
             <td class="px-3 py-2">{row.name}</td>
             <td class="px-3 py-2">{row.requestedDate}</td>
             <td class="px-3 py-2">{row.approvedDate}</td>
-            <td class="px-3 py-2">{row.status}</td>
+            <td class="px-3 py-2">
+              {#if row.receiptUrl}
+                <a
+                  href={row.receiptUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class="inline-flex items-center gap-1 text-orange-500 hover:underline"
+                >
+                  <Icon icon="ph:file-pdf-light" class="text-lg" />
+                  พิมพ์ใบเสร็จ
+                </a>
+              {:else}
+                {row.status}
+              {/if}
+            </td>
           </tr>
         {/each}
       </tbody>

--- a/src/pages/PaymentReceipt.svelte
+++ b/src/pages/PaymentReceipt.svelte
@@ -1,0 +1,96 @@
+<script lang="ts">
+  import PageShell from "../libs/components/common/PageShell.svelte";
+  import PageHeader from "../libs/components/common/PageHeader.svelte";
+  import Icon from "@iconify/svelte";
+  import { submitForm } from "../libs/utils/formSubmit";
+  import type { PaymentReceiptData } from "../libs/types/payment-receipt.types";
+
+  export let yearOptions: PaymentReceiptData["yearOptions"] = [];
+  export let semesterOptions: PaymentReceiptData["semesterOptions"] = [];
+  export let selectedYear: PaymentReceiptData["selectedYear"] = "";
+  export let selectedSemester: PaymentReceiptData["selectedSemester"] = "";
+  export let records: PaymentReceiptData["records"] = [];
+  export let documents: PaymentReceiptData["documents"] = [];
+
+  let year = selectedYear || yearOptions[0] || "";
+  let semester = selectedSemester || semesterOptions[0] || "";
+
+  const selectClass =
+    "rounded-xl border dark:border-white/10 border-slate-200 dark:bg-gray-900 bg-white px-3 py-2 text-sm";
+
+  // Changing the term reloads this same page with the new selection.
+  function reload() {
+    submitForm(location.origin + location.pathname, { year, semester });
+  }
+</script>
+
+<PageShell>
+  <PageHeader title="พิมพ์ใบเสร็จ / เอกสารการเงิน" lines={[]} />
+
+  <div class="mt-4 flex flex-wrap items-center gap-3">
+    <span class="text-sm text-slate-500 dark:text-slate-400">ปีการศึกษา</span>
+    <select bind:value={year} on:change={reload} class={selectClass}>
+      {#each yearOptions as y (y)}<option value={y}>{y}</option>{/each}
+    </select>
+    <span class="text-sm text-slate-500 dark:text-slate-400">ภาคการศึกษา</span>
+    <select bind:value={semester} on:change={reload} class={selectClass}>
+      {#each semesterOptions as s (s)}<option value={s}>{s}</option>{/each}
+    </select>
+  </div>
+
+  <div
+    class="mt-4 overflow-x-auto rounded-2xl border dark:border-white/10 border-slate-200"
+  >
+    <table class="w-full text-sm">
+      <thead
+        class="dark:bg-white/5 bg-slate-100 text-slate-500 dark:text-slate-400"
+      >
+        <tr>
+          <th class="px-3 py-2 text-left font-medium">รหัสนักศึกษา</th>
+          <th class="px-3 py-2 text-left font-medium">ชื่อ-สกุล</th>
+          <th class="px-3 py-2 text-left font-medium">วันที่ขอ</th>
+          <th class="px-3 py-2 text-left font-medium">วันที่อนุมัติ</th>
+          <th class="px-3 py-2 text-left font-medium">สถานะ</th>
+        </tr>
+      </thead>
+      <tbody>
+        {#each records as row, i (row.studentId + i)}
+          <tr class="border-t dark:border-white/10 border-slate-200">
+            <td class="px-3 py-2">{row.studentId}</td>
+            <td class="px-3 py-2">{row.name}</td>
+            <td class="px-3 py-2">{row.requestedDate}</td>
+            <td class="px-3 py-2">{row.approvedDate}</td>
+            <td class="px-3 py-2">{row.status}</td>
+          </tr>
+        {/each}
+      </tbody>
+    </table>
+  </div>
+  {#if records.length === 0}
+    <p class="mt-3 text-center text-sm text-slate-500 dark:text-slate-400">
+      ไม่พบรายการคำขอในภาคการศึกษานี้
+    </p>
+  {/if}
+
+  {#if documents.length}
+    <h2 class="mt-6 mb-2 text-sm font-semibold text-orange-500">
+      เอกสารประกอบการเบิก
+    </h2>
+    <div class="grid gap-2 sm:grid-cols-2">
+      {#each documents as doc (doc.url)}
+        <a
+          href={doc.url}
+          target="_blank"
+          rel="noopener noreferrer"
+          class="flex items-center gap-3 rounded-xl border dark:border-white/10 border-slate-200 dark:bg-white/5 bg-slate-50 px-4 py-3 hover:border-orange-500/50 transition-colors"
+        >
+          <Icon
+            icon="ph:file-pdf-light"
+            class="text-2xl text-orange-500 shrink-0"
+          />
+          <span class="text-sm">{doc.name}</span>
+        </a>
+      {/each}
+    </div>
+  {/if}
+</PageShell>

--- a/src/pages/PaymentReceipt.svelte
+++ b/src/pages/PaymentReceipt.svelte
@@ -77,7 +77,7 @@
       เอกสารประกอบการเบิก
     </h2>
     <div class="grid gap-2 sm:grid-cols-2">
-      {#each documents as doc (doc.url)}
+      {#each documents as doc, i (doc.url + "-" + i)}
         <a
           href={doc.url}
           target="_blank"

--- a/src/pages/PaymentReceipt.svelte
+++ b/src/pages/PaymentReceipt.svelte
@@ -29,11 +29,21 @@
 
   <div class="mt-4 flex flex-wrap items-center gap-3">
     <span class="text-sm text-slate-500 dark:text-slate-400">ปีการศึกษา</span>
-    <select bind:value={year} on:change={reload} class={selectClass}>
+    <select
+      bind:value={year}
+      on:change={reload}
+      class={selectClass}
+      aria-label="ปีการศึกษา"
+    >
       {#each yearOptions as y (y)}<option value={y}>{y}</option>{/each}
     </select>
     <span class="text-sm text-slate-500 dark:text-slate-400">ภาคการศึกษา</span>
-    <select bind:value={semester} on:change={reload} class={selectClass}>
+    <select
+      bind:value={semester}
+      on:change={reload}
+      class={selectClass}
+      aria-label="ภาคการศึกษา"
+    >
       {#each semesterOptions as s (s)}<option value={s}>{s}</option>{/each}
     </select>
   </div>


### PR DESCRIPTION
Third Phase 4 batch: a receipt/documents page and the email preference setting.

## New pages
- payment-receipt (payment/print_receipt.php): year/semester selector that reloads the page, a table of receipt requests (id, name, requested/approved dates, status), and downloadable fee documents.
- email-config (u_student/email_config.php): email notification preference radios with a Save button.

## Details
- Shared submitForm helper for the native multipart form POST (used by both pages).
- New scrapers (PaymentReceiptScraper, EmailConfigScraper) with synthetic-HTML unit tests. 30 tests total.
- Registered both pages; bumped dev to 2.5.3.

## Important: the forms have side effects
email-config saves a preference and the selector/save posts back to the registrar. These mirror the native form exactly (field names group0/ssid/Submit, action, multipart enctype, and the live-read session token), but a submission cannot be exercised in CI or offline without actually changing the setting. Please confirm on a live login:
- changing the email radio and saving persists the choice,
- the payment year/semester selector reloads with the right term,
- the fee-document PDF links open.

## Verification
- typecheck: 0 errors (1 pre-existing warning)
- eslint: 0 errors
- vitest: 30 tests pass
- Chrome and Firefox build