### PR TITLE
Phase 4: bug report form page

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kmitl-x",
   "description": "Transform KMITL Student Information System UI/UX with enhanced features for a better experience.",
-  "version": "2.5.3",
+  "version": "2.5.4",
   "license": "MIT",
   "type": "module",
   "scripts": {

--- a/src/libs/registry/pageManifest.ts
+++ b/src/libs/registry/pageManifest.ts
@@ -134,6 +134,15 @@ export const pages: PageDefinition[] = [
     component: () => import("../../pages/EmailConfig.svelte"),
   },
   {
+    name: "bug-report",
+    match: /bug\/report\.php/,
+    scraper: () =>
+      import("../scraper/bug-report.scraper").then(
+        (m) => new m.BugReportScraper()
+      ),
+    component: () => import("../../pages/BugReport.svelte"),
+  },
+  {
     // static image page, kept as a placeholder rather than reskinned
     name: "grade-process",
     match: /u_student\/grade_process\.php/,

--- a/src/libs/scraper/bug-report.scraper.test.ts
+++ b/src/libs/scraper/bug-report.scraper.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from "vitest";
+import { BugReportScraper } from "./bug-report.scraper";
+
+describe("BugReportScraper", () => {
+  it("extracts the header, type options, session token, and action", async () => {
+    const html = `
+      <div id="div_student_id">&nbsp;68010488</div>
+      <div id="div_tname">&nbsp;First&nbsp;&nbsp;Last</div>
+      <div id="div_semester">&nbsp;1/2565</div>
+      <form action="https://x/bug/save.php" method="post">
+        <select name="type" id="type">
+          <option value="0">แจ้งปัญหา</option>
+          <option value="1">แนะนำ</option>
+          <option value="2">สอบถาม</option>
+        </select>
+        <input name="topic" type="text" id="topic">
+        <textarea name="detail" id="detail"></textarea>
+        <input name="ssid" type="hidden" id="ssid" value="tok123">
+      </form>`;
+    const doc = new DOMParser().parseFromString(html, "text/html");
+    const r = await new BugReportScraper().scrape(doc);
+
+    expect(r.studentId).toBe("68010488");
+    expect(r.name).toBe("First Last");
+    expect(r.semester).toBe("1/2565");
+    expect(r.typeOptions).toHaveLength(3);
+    expect(r.typeOptions[0]).toEqual({ value: "0", label: "แจ้งปัญหา" });
+    expect(r.ssid).toBe("tok123");
+    expect(r.action).toContain("bug/save.php");
+  });
+});

--- a/src/libs/scraper/bug-report.scraper.ts
+++ b/src/libs/scraper/bug-report.scraper.ts
@@ -23,10 +23,12 @@ export class BugReportScraper extends BaseScraper {
       document.querySelector<HTMLInputElement>("#ssid, input[name='ssid']")
         ?.value || "";
 
-    const form = document.querySelector<HTMLFormElement>(
-      "form[action*='save.php'], form"
+    // Prefer the save form; fall back to the known endpoint rather than some
+    // other form that might be on the page.
+    const saveForm = document.querySelector<HTMLFormElement>(
+      "form[action*='save.php']"
     );
-    const action = form?.action || `${location.origin}/bug/save.php`;
+    const action = saveForm?.action || `${location.origin}/bug/save.php`;
 
     return { studentId, name, semester, typeOptions, ssid, action };
   }

--- a/src/libs/scraper/bug-report.scraper.ts
+++ b/src/libs/scraper/bug-report.scraper.ts
@@ -1,0 +1,33 @@
+import type { BugReportData, BugTypeOption } from "../types/bug-report.types";
+import { BaseScraper } from "./baseScraper";
+import { getStudentHeader, getDivText } from "../utils/studentHeader";
+
+export class BugReportScraper extends BaseScraper {
+  public async scrape(document: Document): Promise<BugReportData> {
+    const { studentId, name } = getStudentHeader(document);
+    const semester = getDivText(document, "div_semester");
+
+    const typeSelect = document.querySelector<HTMLSelectElement>(
+      "#type, select[name='type']"
+    );
+    const typeOptions: BugTypeOption[] = typeSelect
+      ? Array.from(
+          typeSelect.querySelectorAll<HTMLOptionElement>("option")
+        ).map((o) => ({
+          value: o.value,
+          label: (o.textContent || "").replace(/\s+/g, " ").trim(),
+        }))
+      : [];
+
+    const ssid =
+      document.querySelector<HTMLInputElement>("#ssid, input[name='ssid']")
+        ?.value || "";
+
+    const form = document.querySelector<HTMLFormElement>(
+      "form[action*='save.php'], form"
+    );
+    const action = form?.action || `${location.origin}/bug/save.php`;
+
+    return { studentId, name, semester, typeOptions, ssid, action };
+  }
+}

--- a/src/libs/types/bug-report.types.ts
+++ b/src/libs/types/bug-report.types.ts
@@ -1,0 +1,13 @@
+export interface BugTypeOption {
+  value: string;
+  label: string;
+}
+
+export interface BugReportData {
+  studentId: string;
+  name: string;
+  semester: string;
+  typeOptions: BugTypeOption[];
+  ssid: string;
+  action: string;
+}

--- a/src/pages/BugReport.svelte
+++ b/src/pages/BugReport.svelte
@@ -1,0 +1,86 @@
+<script lang="ts">
+  import PageShell from "../libs/components/common/PageShell.svelte";
+  import PageHeader from "../libs/components/common/PageHeader.svelte";
+  import { submitForm } from "../libs/utils/formSubmit";
+  import type { BugReportData } from "../libs/types/bug-report.types";
+
+  export let studentId: BugReportData["studentId"] = "";
+  export let name: BugReportData["name"] = "";
+  export let semester: BugReportData["semester"] = "";
+  export let typeOptions: BugReportData["typeOptions"] = [];
+  export let ssid: BugReportData["ssid"] = "";
+  export let action: BugReportData["action"] = "";
+
+  let type = typeOptions[0]?.value ?? "0";
+  let topic = "";
+  let detail = "";
+  let saving = false;
+
+  $: canSubmit = !!(topic.trim() && detail.trim() && ssid && !saving);
+
+  const fieldClass =
+    "mt-1 w-full rounded-xl border dark:border-white/10 border-slate-200 dark:bg-gray-900 bg-white px-3 py-2 text-sm";
+
+  // Mirror the native form: url-encoded POST to bug/save.php.
+  function submit() {
+    if (!canSubmit) return;
+    saving = true;
+    submitForm(
+      action,
+      { type, topic, detail, ssid, button: "[บันทึก]" },
+      "application/x-www-form-urlencoded"
+    );
+  }
+</script>
+
+<PageShell>
+  <PageHeader
+    title="แจ้งปัญหา / เสนอแนะ"
+    lines={[`${studentId} ${name}`, `ภาคการศึกษา ${semester}`]}
+  />
+
+  <div
+    class="mt-4 max-w-2xl mx-auto rounded-2xl border dark:border-white/10 border-slate-200 dark:bg-white/5 bg-slate-50 p-6"
+  >
+    <p class="text-sm text-slate-500 dark:text-slate-400 mb-4">
+      โปรดใส่รายละเอียดของปัญหาที่พบให้มากที่สุด
+      เพื่อให้ผู้พัฒนาตรวจสอบและแก้ไขได้รวดเร็ว
+    </p>
+
+    <div class="space-y-4">
+      <label class="block">
+        <span class="text-sm text-slate-500 dark:text-slate-400">ประเภท</span>
+        <select bind:value={type} class={fieldClass}>
+          {#each typeOptions as opt (opt.value)}
+            <option value={opt.value}>{opt.label}</option>
+          {/each}
+        </select>
+      </label>
+
+      <label class="block">
+        <span class="text-sm text-slate-500 dark:text-slate-400">หัวข้อ</span>
+        <input
+          bind:value={topic}
+          type="text"
+          maxlength="200"
+          class={fieldClass}
+        />
+      </label>
+
+      <label class="block">
+        <span class="text-sm text-slate-500 dark:text-slate-400"
+          >รายละเอียด</span
+        >
+        <textarea bind:value={detail} rows="8" class={fieldClass}></textarea>
+      </label>
+
+      <button
+        on:click={submit}
+        disabled={!canSubmit}
+        class="w-full rounded-xl bg-orange-500 text-white font-semibold py-2.5 hover:bg-orange-600 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+      >
+        บันทึก
+      </button>
+    </div>
+  </div>
+</PageShell>


### PR DESCRIPTION
Reskin the report-a-problem form (bug/report.php).

## What it does
- Student header, a type selector (report / suggest / ask), a topic input, and a detail textarea.
- Submits url-encoded to bug/save.php with the live session token (ssid) and the native button field, mirroring the native form exactly.
- The submit button is disabled until topic and detail are filled.

## Details
- New BugReportScraper (student header via the shared helper, type options, ssid, form action) with a synthetic-HTML unit test.
- Verified against the real page snapshot: header, semester, Thai type labels, ssid, and action all parse correctly.
- Registered the page; bumped dev to 2.5.4. 31 tests total.

## Verification
- typecheck: 0 errors (1 pre-existing warning)
- eslint: 0 errors
- vitest: 31 tests pass
- Chrome and Firefox build

## Needs a live pass
Submitting posts to bug/save.php (a real side effect), which cannot be exercised in CI. Please confirm on a live login that a submitted report goes through and the type/topic/detail arrive correctly.