### PR TITLE
Phase 5: GPA what-if calculator on the grade page

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kmitl-x",
   "description": "Transform KMITL Student Information System UI/UX with enhanced features for a better experience.",
-  "version": "2.5.4",
+  "version": "2.6.0",
   "license": "MIT",
   "type": "module",
   "scripts": {

--- a/src/libs/components/gpa/GpaCalculator.svelte
+++ b/src/libs/components/gpa/GpaCalculator.svelte
@@ -116,24 +116,28 @@
   </div>
 
   <div class="space-y-2">
-    {#each rows as row (row.id)}
+    {#each rows as row, i (row.id)}
       <div class="flex items-center gap-2">
         {#if row.fixed}
           <span class="flex-1 text-sm truncate" title={row.name}
             >{row.name}</span
           >
         {:else}
-          <input bind:value={row.name} class="flex-1 {fieldClass}" />
+          <input bind:value={rows[i].name} class="flex-1 {fieldClass}" />
         {/if}
         <input
           type="number"
-          bind:value={row.credit}
+          bind:value={rows[i].credit}
           min="0"
           step="1"
           aria-label="หน่วยกิต"
           class="w-16 text-center {fieldClass}"
         />
-        <select bind:value={row.grade} aria-label="เกรด" class="w-20 {fieldClass}">
+        <select
+          bind:value={rows[i].grade}
+          aria-label="เกรด"
+          class="w-20 {fieldClass}"
+        >
           {#each GRADE_OPTIONS as g (g)}
             <option value={g}>{g}</option>
           {/each}

--- a/src/libs/components/gpa/GpaCalculator.svelte
+++ b/src/libs/components/gpa/GpaCalculator.svelte
@@ -1,0 +1,162 @@
+<script lang="ts">
+  import Icon from "@iconify/svelte";
+  import { GRADE_OPTIONS, computeGpa, gradePoint } from "../../utils/gpa";
+  import type {
+    GradeSummaryTable,
+    GradeTableObject,
+  } from "../../types/report-gradetable.types";
+
+  export let gradeTable: GradeTableObject[] = [];
+  export let gradeSummary: GradeSummaryTable;
+
+  interface Row {
+    id: number;
+    name: string;
+    credit: number;
+    grade: string;
+    fixed: boolean;
+  }
+
+  let nextId = 0;
+
+  // Seed the calculator with the courses that carry a letter grade.
+  function initialRows(): Row[] {
+    nextId = 0;
+    return gradeTable
+      .filter((c) => gradePoint(c.grade) !== null)
+      .map((c) => ({
+        id: nextId++,
+        name: c.subjectName,
+        credit: c.credit,
+        grade: c.grade.trim().toUpperCase(),
+        fixed: true,
+      }));
+  }
+
+  let rows: Row[] = initialRows();
+
+  // Prior cumulative, derived from the previous-semester summary. Deriving
+  // credits from gradePoints / gpa avoids guessing which CA/CP/CD column counts.
+  $: priorGradePoints = parseFloat(gradeSummary?.preSemester?.gp ?? "") || 0;
+  $: priorGpa = parseFloat(gradeSummary?.preSemester?.gpsGpa ?? "") || 0;
+  $: priorCredits = priorGpa > 0 ? priorGradePoints / priorGpa : 0;
+
+  $: semester = computeGpa(rows);
+  $: totalCredits = priorCredits + semester.credits;
+  $: projectedGpax =
+    totalCredits > 0
+      ? (priorGradePoints + semester.gradePoints) / totalCredits
+      : 0;
+
+  $: actualGpax = parseFloat(gradeSummary?.cumulation?.gpsGpa ?? "") || 0;
+  $: gpaxDelta = projectedGpax - actualGpax;
+
+  function addCourse() {
+    rows = [
+      ...rows,
+      { id: nextId++, name: "วิชาใหม่", credit: 3, grade: "A", fixed: false },
+    ];
+  }
+
+  function removeCourse(id: number) {
+    rows = rows.filter((r) => r.id !== id);
+  }
+
+  function reset() {
+    rows = initialRows();
+  }
+
+  const fieldClass =
+    "rounded-lg border dark:border-white/10 border-slate-200 dark:bg-gray-900 bg-white px-2 py-1 text-sm";
+</script>
+
+<div
+  class="rounded-2xl border dark:border-white/10 border-slate-200 dark:bg-white/5 bg-slate-50 p-5"
+>
+  <div class="flex items-center justify-between mb-3">
+    <h2
+      class="text-sm font-semibold text-orange-500 flex items-center gap-2"
+    >
+      <Icon icon="mdi:calculator-variant-outline" class="text-lg" /> คำนวณเกรด (What-if)
+    </h2>
+    <button
+      on:click={reset}
+      class="text-xs text-slate-400 hover:text-orange-500 transition-colors"
+    >
+      รีเซ็ต
+    </button>
+  </div>
+
+  <div class="grid grid-cols-2 gap-3 mb-4">
+    <div
+      class="rounded-xl border dark:border-white/10 border-slate-200 p-3 text-center"
+    >
+      <p class="text-xs text-slate-400">GPA เทอมนี้</p>
+      <p class="text-2xl font-bold text-orange-500">
+        {semester.gpa.toFixed(2)}
+      </p>
+    </div>
+    <div
+      class="rounded-xl border dark:border-white/10 border-slate-200 p-3 text-center"
+    >
+      <p class="text-xs text-slate-400">GPAX สะสม (คาดการณ์)</p>
+      <p class="text-2xl font-bold text-orange-500">
+        {projectedGpax.toFixed(2)}
+      </p>
+      {#if actualGpax}
+        <p
+          class="text-xs {gpaxDelta >= 0 ? 'text-green-500' : 'text-red-500'}"
+        >
+          {gpaxDelta >= 0 ? "+" : ""}{gpaxDelta.toFixed(2)} จาก {actualGpax.toFixed(
+            2
+          )}
+        </p>
+      {/if}
+    </div>
+  </div>
+
+  <div class="space-y-2">
+    {#each rows as row (row.id)}
+      <div class="flex items-center gap-2">
+        {#if row.fixed}
+          <span class="flex-1 text-sm truncate" title={row.name}
+            >{row.name}</span
+          >
+        {:else}
+          <input bind:value={row.name} class="flex-1 {fieldClass}" />
+        {/if}
+        <input
+          type="number"
+          bind:value={row.credit}
+          min="0"
+          step="1"
+          aria-label="หน่วยกิต"
+          class="w-16 text-center {fieldClass}"
+        />
+        <select bind:value={row.grade} aria-label="เกรด" class="w-20 {fieldClass}">
+          {#each GRADE_OPTIONS as g (g)}
+            <option value={g}>{g}</option>
+          {/each}
+        </select>
+        {#if row.fixed}
+          <span class="w-6"></span>
+        {:else}
+          <button
+            on:click={() => removeCourse(row.id)}
+            aria-label="ลบวิชา"
+            class="w-6 text-slate-400 hover:text-red-500 transition-colors"
+          >
+            <Icon icon="mdi:close" />
+          </button>
+        {/if}
+      </div>
+    {/each}
+  </div>
+
+  <button
+    on:click={addCourse}
+    class="mt-3 text-xs text-orange-500 hover:underline flex items-center gap-1"
+  >
+    <Icon icon="mdi:plus" /> เพิ่มวิชา
+  </button>
+</div>

--- a/src/libs/utils/gpa.test.ts
+++ b/src/libs/utils/gpa.test.ts
@@ -8,6 +8,11 @@ describe("gradePoint", () => {
     expect(gradePoint("F")).toBe(0);
   });
 
+  it("normalizes case and surrounding whitespace", () => {
+    expect(gradePoint(" a ")).toBe(4);
+    expect(gradePoint("b+")).toBe(3.5);
+  });
+
   it("returns null for non-GPA grades", () => {
     expect(gradePoint("W")).toBeNull();
     expect(gradePoint("S")).toBeNull();

--- a/src/libs/utils/gpa.test.ts
+++ b/src/libs/utils/gpa.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from "vitest";
+import { computeGpa, gradePoint } from "./gpa";
+
+describe("gradePoint", () => {
+  it("maps letter grades to points", () => {
+    expect(gradePoint("A")).toBe(4);
+    expect(gradePoint("B+")).toBe(3.5);
+    expect(gradePoint("F")).toBe(0);
+  });
+
+  it("returns null for non-GPA grades", () => {
+    expect(gradePoint("W")).toBeNull();
+    expect(gradePoint("S")).toBeNull();
+    expect(gradePoint("")).toBeNull();
+  });
+});
+
+describe("computeGpa", () => {
+  it("computes a credit-weighted GPA", () => {
+    const r = computeGpa([
+      { credit: 3, grade: "A" }, // 12
+      { credit: 3, grade: "B" }, // 9
+      { credit: 2, grade: "C" }, // 4
+    ]);
+    expect(r.credits).toBe(8);
+    expect(r.gradePoints).toBe(25);
+    expect(r.gpa).toBeCloseTo(3.125, 3);
+  });
+
+  it("ignores non-GPA grades and zero-credit rows", () => {
+    const r = computeGpa([
+      { credit: 3, grade: "A" },
+      { credit: 3, grade: "W" },
+      { credit: 0, grade: "A" },
+    ]);
+    expect(r.credits).toBe(3);
+    expect(r.gpa).toBe(4);
+  });
+
+  it("returns 0 when there are no graded credits", () => {
+    expect(computeGpa([]).gpa).toBe(0);
+  });
+});

--- a/src/libs/utils/gpa.ts
+++ b/src/libs/utils/gpa.ts
@@ -1,0 +1,43 @@
+// KMITL letter-grade scale. Grades not listed here (W, S, U, I, ...) do not
+// count toward the GPA.
+export const GRADE_POINTS: Record<string, number> = {
+  A: 4,
+  "B+": 3.5,
+  B: 3,
+  "C+": 2.5,
+  C: 2,
+  "D+": 1.5,
+  D: 1,
+  F: 0,
+};
+
+export const GRADE_OPTIONS = ["A", "B+", "B", "C+", "C", "D+", "D", "F"];
+
+export function gradePoint(grade: string): number | null {
+  const g = grade.trim().toUpperCase();
+  return g in GRADE_POINTS ? GRADE_POINTS[g] : null;
+}
+
+export interface GpaInput {
+  credit: number;
+  grade: string;
+}
+
+export interface GpaResult {
+  gradePoints: number;
+  credits: number;
+  gpa: number;
+}
+
+// Sum grade points and credits over the courses that carry a letter grade.
+export function computeGpa(courses: GpaInput[]): GpaResult {
+  let gradePoints = 0;
+  let credits = 0;
+  for (const course of courses) {
+    const point = gradePoint(course.grade);
+    if (point === null || !(course.credit > 0)) continue;
+    gradePoints += point * course.credit;
+    credits += course.credit;
+  }
+  return { gradePoints, credits, gpa: credits > 0 ? gradePoints / credits : 0 };
+}

--- a/src/pages/GradeReport.svelte
+++ b/src/pages/GradeReport.svelte
@@ -2,6 +2,7 @@
   import PageShell from "../libs/components/common/PageShell.svelte";
   import PageHeader from "../libs/components/common/PageHeader.svelte";
   import Icon from "@iconify/svelte";
+  import GpaCalculator from "../libs/components/gpa/GpaCalculator.svelte";
   import type { ReportGradeTable } from "../libs/types/report-gradetable.types";
 
   export let studentInfo: ReportGradeTable["studentInfo"];
@@ -101,6 +102,10 @@
       </table>
     </div>
   {/if}
+
+  <div class="mt-4">
+    <GpaCalculator {gradeTable} {gradeSummary} />
+  </div>
 
   {#if gradeSymbol && gradeSymbol.symbols.length}
     <div


### PR DESCRIPTION
First Phase 5 feature: an interactive GPA / what-if calculator on the grade report page, using the grade data already scraped.

## What it does
- Seeds from the semester's letter-graded courses.
- Change any grade or add hypothetical courses (name, credit, grade) and see, live:
  - the semester GPA, and
  - the projected cumulative GPAX, with the delta from the current GPAX.
- Reset returns to the actual grades.

## Correctness
- New pure `gpa` util (KMITL A..F scale, credit-weighted GPA) with unit tests.
- Prior cumulative is derived from the previous-semester summary as gradePoints / gpa, which avoids guessing which CA/CP/CD column counts toward GPA.
- Verified against the real grade page: the computed semester GPA (3.00) and projected GPAX (3.13) match the registrar's own numbers exactly.

## Verification
- typecheck: 0 errors (1 pre-existing warning)
- eslint: 0 errors
- vitest: 36 tests pass
- Chrome and Firefox build

Bumps dev to 2.6.0 (start of Phase 5).