### PR TITLE
Phase 5: Ctrl-K command palette

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kmitl-x",
   "description": "Transform KMITL Student Information System UI/UX with enhanced features for a better experience.",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "license": "MIT",
   "type": "module",
   "scripts": {

--- a/src/libs/components/common/CommandPalette.svelte
+++ b/src/libs/components/common/CommandPalette.svelte
@@ -1,0 +1,117 @@
+<script lang="ts">
+  import { onMount, onDestroy } from "svelte";
+  import Icon from "@iconify/svelte";
+  import { loadMenu, type MenuLink } from "../../utils/menu";
+
+  let open = false;
+  let query = "";
+  let items: MenuLink[] = [];
+  let activeIndex = 0;
+  let inputEl: HTMLInputElement | undefined;
+
+  $: filtered = query.trim()
+    ? items.filter((it) =>
+        it.label.toLowerCase().includes(query.trim().toLowerCase())
+      )
+    : items;
+
+  // Keep the highlight in range as the filter narrows.
+  $: if (activeIndex > filtered.length - 1) activeIndex = 0;
+
+  function openPalette() {
+    items = loadMenu();
+    query = "";
+    activeIndex = 0;
+    open = true;
+    setTimeout(() => inputEl?.focus(), 0);
+  }
+
+  function closePalette() {
+    open = false;
+  }
+
+  function go(item: MenuLink | undefined) {
+    if (!item) return;
+    closePalette();
+    window.location.href = item.url;
+  }
+
+  function onKeydown(e: KeyboardEvent) {
+    if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === "k") {
+      e.preventDefault();
+      if (open) closePalette();
+      else openPalette();
+      return;
+    }
+    if (!open) return;
+    if (e.key === "Escape") {
+      e.preventDefault();
+      closePalette();
+    } else if (e.key === "ArrowDown") {
+      e.preventDefault();
+      activeIndex = Math.min(activeIndex + 1, filtered.length - 1);
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      activeIndex = Math.max(activeIndex - 1, 0);
+    } else if (e.key === "Enter") {
+      e.preventDefault();
+      go(filtered[activeIndex]);
+    }
+  }
+
+  onMount(() => window.addEventListener("keydown", onKeydown));
+  onDestroy(() => window.removeEventListener("keydown", onKeydown));
+</script>
+
+{#if open}
+  <div
+    class="fixed inset-0 z-[2147483000] flex items-start justify-center pt-24 bg-black/40 font-prompt"
+    role="presentation"
+    on:click={closePalette}
+  >
+    <!-- svelte-ignore a11y-click-events-have-key-events a11y-no-static-element-interactions -->
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label="ค้นหาเมนู"
+      tabindex="-1"
+      class="w-full max-w-lg mx-4 rounded-2xl bg-white dark:bg-gray-900 border dark:border-white/10 border-slate-200 shadow-2xl overflow-hidden"
+      on:click|stopPropagation
+    >
+      <div
+        class="flex items-center gap-2 px-4 border-b dark:border-white/10 border-slate-200"
+      >
+        <Icon icon="mdi:magnify" class="text-slate-400 text-lg" />
+        <input
+          bind:this={inputEl}
+          bind:value={query}
+          placeholder="ค้นหาเมนู..."
+          class="flex-1 py-3 bg-transparent outline-none text-sm dark:text-white text-gray-900"
+        />
+        <kbd class="text-xs text-slate-400">Esc</kbd>
+      </div>
+
+      <div class="max-h-80 overflow-y-auto py-1">
+        {#each filtered as item, i (item.url + "-" + i)}
+          <button
+            class="w-full text-left px-4 py-2 text-sm flex items-center gap-2 {i ===
+            activeIndex
+              ? 'bg-orange-500/10 text-orange-500'
+              : 'text-gray-700 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-white/5'}"
+            on:click={() => go(item)}
+            on:mouseenter={() => (activeIndex = i)}
+          >
+            <Icon icon="mdi:chevron-right" class="text-slate-400 shrink-0" />
+            <span class="truncate">{item.label}</span>
+          </button>
+        {/each}
+
+        {#if filtered.length === 0}
+          <p class="px-4 py-6 text-center text-sm text-slate-400">
+            {items.length === 0 ? "เปิดหน้าแรกพอร์ทัลเพื่อโหลดเมนู" : "ไม่พบเมนู"}
+          </p>
+        {/if}
+      </div>
+    </div>
+  </div>
+{/if}

--- a/src/libs/components/common/CommandPalette.svelte
+++ b/src/libs/components/common/CommandPalette.svelte
@@ -30,8 +30,22 @@
     open = false;
   }
 
+  // Only navigate to KMITL http(s) URLs. The menu comes from storage, which the
+  // host page shares and could write to.
+  function isSafeUrl(url: string): boolean {
+    try {
+      const u = new URL(url, location.href);
+      if (u.protocol !== "https:" && u.protocol !== "http:") return false;
+      return (
+        u.hostname === location.hostname || u.hostname.endsWith(".kmitl.ac.th")
+      );
+    } catch {
+      return false;
+    }
+  }
+
   function go(item: MenuLink | undefined) {
-    if (!item) return;
+    if (!item || !isSafeUrl(item.url)) return;
     closePalette();
     window.location.href = item.url;
   }
@@ -49,7 +63,7 @@
       closePalette();
     } else if (e.key === "ArrowDown") {
       e.preventDefault();
-      activeIndex = Math.min(activeIndex + 1, filtered.length - 1);
+      activeIndex = Math.max(0, Math.min(activeIndex + 1, filtered.length - 1));
     } else if (e.key === "ArrowUp") {
       e.preventDefault();
       activeIndex = Math.max(activeIndex - 1, 0);
@@ -86,6 +100,7 @@
           bind:this={inputEl}
           bind:value={query}
           placeholder="ค้นหาเมนู..."
+          aria-label="ค้นหาเมนู"
           class="flex-1 py-3 bg-transparent outline-none text-sm dark:text-white text-gray-900"
         />
         <kbd class="text-xs text-slate-400">Esc</kbd>

--- a/src/libs/handler/uiHandler.ts
+++ b/src/libs/handler/uiHandler.ts
@@ -1,6 +1,7 @@
 import { mount } from "svelte";
 import tailwind from "../../assets/css/tailwind.css?inline";
 import { getTheme } from "../utils/themeManager";
+import CommandPalette from "../components/common/CommandPalette.svelte";
 
 // Wait for DOM to be ready
 export function onDOMReady(): Promise<void> {
@@ -102,6 +103,8 @@ export async function mountUI(
       target: appRoot,
       props,
     });
+    // Global command palette (Ctrl-K) available on every reskinned page.
+    mount(CommandPalette, { target: appRoot });
     resolve();
   });
 }

--- a/src/libs/utils/menu.ts
+++ b/src/libs/utils/menu.ts
@@ -18,7 +18,16 @@ export function saveMenu(links: MenuLink[]): void {
 export function loadMenu(): MenuLink[] {
   try {
     const raw = localStorage.getItem(MENU_KEY);
-    if (raw) return JSON.parse(raw) as MenuLink[];
+    if (!raw) return [];
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    // The store shares the page's origin, so validate the shape defensively.
+    return parsed.filter(
+      (x): x is MenuLink =>
+        !!x &&
+        typeof (x as MenuLink).label === "string" &&
+        typeof (x as MenuLink).url === "string"
+    );
   } catch {
     // ignore malformed or unavailable storage
   }

--- a/src/libs/utils/menu.ts
+++ b/src/libs/utils/menu.ts
@@ -1,0 +1,26 @@
+// The portal caches its menu here so the command palette can offer it on every
+// page, not just the portal.
+export interface MenuLink {
+  label: string;
+  url: string;
+}
+
+const MENU_KEY = "kmitlx:menu";
+
+export function saveMenu(links: MenuLink[]): void {
+  try {
+    localStorage.setItem(MENU_KEY, JSON.stringify(links));
+  } catch {
+    // localStorage may be unavailable; the palette just has no entries.
+  }
+}
+
+export function loadMenu(): MenuLink[] {
+  try {
+    const raw = localStorage.getItem(MENU_KEY);
+    if (raw) return JSON.parse(raw) as MenuLink[];
+  } catch {
+    // ignore malformed or unavailable storage
+  }
+  return [];
+}

--- a/src/pages/Portal.svelte
+++ b/src/pages/Portal.svelte
@@ -13,6 +13,7 @@
   import type { StudentProfile } from "../libs/types/student.types";
   import { logger } from "../libs/utils/logger";
   import { switchLanguage } from "../libs/i18n";
+  import { saveMenu } from "../libs/utils/menu";
 
   export let meta: PortalScraperResult["meta"];
   export let sections: PortalScraperResult["sections"];
@@ -58,6 +59,16 @@
 
     // Load student data
     loadStudentData();
+
+    // Cache the menu so the command palette can offer it on every page
+    saveMenu(
+      sections.flatMap((section) =>
+        section.items.map((item) => ({
+          label: item.label,
+          url: item.absoluteUrl,
+        }))
+      )
+    );
   });
 
   onDestroy(() => {


### PR DESCRIPTION
A command palette to jump between KMITL pages from anywhere.

## What it does
- Ctrl-K (or Cmd-K) opens the palette on any reskinned page; Ctrl-K again or Esc closes it.
- Type to filter the portal menu; Up/Down to move, Enter to navigate, click to jump.
- The portal caches its menu to localStorage on load, so the palette has entries on every page (not just the portal). If the menu has not been cached yet, it prompts to open the portal home once.

## Wiring
- New CommandPalette.svelte and a small menu cache util (saveMenu/loadMenu).
- Portal caches its flattened menu (label + absolute url) on mount.
- The ui handler mounts the palette globally alongside each page component, so it is available everywhere.

## Verification
- typecheck: 0 errors (1 pre-existing warning)
- eslint: 0 errors
- vitest: 37 tests pass
- Chrome and Firefox build

Bumps dev to 2.7.0.